### PR TITLE
fix: add --needed to pacman -U for Chaotic AUR package installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Blacklist n_hdlc (CVE-2017-2636), ax25, netrom, x25, can, vivid, usb_storage, bluetooth, btusb modules on Proxmox VM where hardware is absent
 - install script creates a security script in the current working directory
 ### Fixed
+- Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run
 - Enable pkgstats.timer via symlink for static unit as it has no [Install] section and cannot be enabled with systemctl enable
 - Remove --permanent flag from firewall-cmd --set-default-zone (incompatible options)
 - Fix SSH cipher names: aes256-gcm and aes128-gcm (no hyphen after aes)

--- a/install
+++ b/install
@@ -34,8 +34,8 @@ ok "pacman.conf configured"
 echo "Configuring Chaotic AUR..."
 pacman-key --recv-key 3056513887B78AEB --keyserver hkps://keyserver.ubuntu.com || die "Could not receive Chaotic AUR key"
 pacman-key --lsign-key 3056513887B78AEB || die "Could not sign Chaotic AUR key"
-pacman -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' --noconfirm || die "Could not install Chaotic AUR keyring"
-pacman -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst' --noconfirm || die "Could not install Chaotic AUR mirrorlist"
+pacman -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' --noconfirm --needed || die "Could not install Chaotic AUR keyring"
+pacman -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst' --noconfirm --needed || die "Could not install Chaotic AUR mirrorlist"
 
 grep -qF "[chaotic-aur]" /etc/pacman.conf || {
 cat << EOF >> /etc/pacman.conf


### PR DESCRIPTION
Add `--needed` flag to the two `pacman -U` calls that install the Chaotic AUR keyring and mirrorlist packages.

Without `--needed`, pacman re-downloads and re-installs these packages on every script run even when they are already up to date. Adding `--needed` makes the installs idempotent — pacman skips the install if the package is already at the same version.

Closes #46