### PR TITLE
feat: replace curl security script with ansible-pull systemd timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Explicitly enforce kernel.perf_event_paranoid=3 to restrict perf_event_open to CAP_SYS_ADMIN
 - Blacklist n_hdlc (CVE-2017-2636), ax25, netrom, x25, can, vivid, usb_storage, bluetooth, btusb modules on Proxmox VM where hardware is absent
 - install script creates a security script in the current working directory
+- Install ansible and configure ansible-pull systemd timer to automatically apply latest system configuration every 6 hours, replacing the manual security script
+- Add site.yml Ansible playbook entry point for ansible-pull
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run
@@ -54,6 +56,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace markr sudoers management with dedicated autoupdate system user (nologin, no home) for yay auto-update
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
+- Remove curl-based security script in favour of ansible-pull timer
 ### Deployment Changes
 
 <!--

--- a/install
+++ b/install
@@ -70,7 +70,7 @@ case "$(uname -r)" in
 esac
 
 echo "Installing packages..."
-pacman -S --noconfirm --needed docker docker-compose docker-buildx git firewalld fail2ban pkgstats reflector pacman-contrib openssh logrotate || die "Could not install packages"
+pacman -S --noconfirm --needed docker docker-compose docker-buildx git firewalld fail2ban pkgstats reflector pacman-contrib openssh logrotate ansible || die "Could not install packages"
 ok "Packages installed"
 
 # ============================================================
@@ -941,24 +941,66 @@ else
 fi
 
 # ============================================================
-# Create security script in current directory
+# Configure ansible-pull for automatic updates
+#
+# ansible-pull inverts the normal Ansible push model: a systemd timer on the
+# managed host periodically runs `ansible-pull`, which checks out the latest
+# version of this repository from GitHub and applies the `site.yml` playbook
+# (which in turn re-runs this `install` script).  This replaces the old
+# `./security` curl-based wrapper with a proper scheduled, pull-based approach.
 # ============================================================
 
-echo "Creating security script..."
-SECURITY_SCRIPT="./security"
-SECURITY_SCRIPT_EXPECTED=$(cat << 'EOF'
-#!  /bin/sh
+echo "Configuring ansible-pull service..."
 
-curl -fsSL https://raw.githubusercontent.com/credfeto/credfeto-setup-arch-vm/refs/heads/main/install | sh
+ANSIBLE_PULL_SERVICE="/etc/systemd/system/ansible-pull.service"
+ANSIBLE_PULL_SERVICE_EXPECTED=$(cat << 'EOF'
+[Unit]
+Description=Ansible Pull - automatic system configuration update
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ansible-pull -U https://github.com/credfeto/credfeto-setup-arch-vm.git -C main site.yml
+StandardOutput=journal
+StandardError=journal
 EOF
 )
-if [ -f "${SECURITY_SCRIPT}" ] && [ "$(cat "${SECURITY_SCRIPT}")" = "${SECURITY_SCRIPT_EXPECTED}" ]; then
-    skip "security script already correct"
+if [ -f "${ANSIBLE_PULL_SERVICE}" ] && [ "$(cat "${ANSIBLE_PULL_SERVICE}")" = "${ANSIBLE_PULL_SERVICE_EXPECTED}" ]; then
+    skip "ansible-pull.service already correct"
 else
-    printf '%s\n' "${SECURITY_SCRIPT_EXPECTED}" > "${SECURITY_SCRIPT}" || die "Could not write ${SECURITY_SCRIPT}"
-    chmod 755 "${SECURITY_SCRIPT}" || die "Could not chmod ${SECURITY_SCRIPT}"
-    ok "security script written"
+    printf '%s\n' "${ANSIBLE_PULL_SERVICE_EXPECTED}" > "${ANSIBLE_PULL_SERVICE}" || die "Could not write ${ANSIBLE_PULL_SERVICE}"
+    ok "ansible-pull.service written"
 fi
+
+echo "Configuring ansible-pull timer..."
+
+ANSIBLE_PULL_TIMER="/etc/systemd/system/ansible-pull.timer"
+ANSIBLE_PULL_TIMER_EXPECTED=$(cat << 'EOF'
+[Unit]
+Description=Run ansible-pull every 6 hours to apply latest system configuration
+Requires=ansible-pull.service
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+)
+if [ -f "${ANSIBLE_PULL_TIMER}" ] && [ "$(cat "${ANSIBLE_PULL_TIMER}")" = "${ANSIBLE_PULL_TIMER_EXPECTED}" ]; then
+    skip "ansible-pull.timer already correct"
+else
+    printf '%s\n' "${ANSIBLE_PULL_TIMER_EXPECTED}" > "${ANSIBLE_PULL_TIMER}" || die "Could not write ${ANSIBLE_PULL_TIMER}"
+    ok "ansible-pull.timer written"
+fi
+
+systemctl daemon-reload || die "Could not reload systemd daemon after ansible-pull unit changes"
+systemctl enable --now ansible-pull.timer || die "Could not enable ansible-pull.timer"
+ok "ansible-pull.timer enabled and started"
 
 # ============================================================
 # Reboot check

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,30 @@
+---
+# ansible-pull entry point
+#
+# This playbook is invoked by ansible-pull running on the managed host:
+#
+#   ansible-pull -U https://github.com/credfeto/credfeto-setup-arch-vm.git -C main site.yml
+#
+# ansible-pull checks out the repository to a local working directory and then
+# runs this playbook against localhost.  The single task here delegates all
+# real configuration work to the idempotent `install` shell script that lives
+# alongside this file in the repository root.
+#
+# Why a shell script rather than native Ansible tasks?
+# The `install` script is the authoritative source of truth for this system's
+# configuration.  Duplicating its logic in YAML would create drift risk and
+# maintenance overhead.  Calling the script from Ansible lets us gain the
+# scheduling and pull-based delivery benefits of ansible-pull while keeping a
+# single implementation.
+
+- name: Apply system configuration via install script
+  hosts: localhost
+  connection: local
+  become: true
+
+  tasks:
+    - name: Run install script
+      ansible.builtin.command:
+        cmd: "{{ playbook_dir }}/install"
+        chdir: "{{ playbook_dir }}"
+      changed_when: true


### PR DESCRIPTION
## Summary

Replaces the manual `./security` curl-based wrapper script with a proper pull-based automation using `ansible-pull`.

### Changes

- **Added** `ansible` to the package install list
- **Added** `site.yml` — a minimal Ansible playbook that serves as the `ansible-pull` entry point, delegating to the existing `install` script
- **Added** `ansible-pull.service` and `ansible-pull.timer` systemd units, configured and enabled by the install script
  - Runs every 6 hours with a 10-minute randomised delay
  - Triggers on boot after 5 minutes
  - Requires network-online.target
- **Removed** the `./security` curl-based script section

### How it works

```
systemd timer (every 6h)
  → ansible-pull
    → git checkout latest repo from GitHub
      → site.yml playbook
        → install script (idempotent)
```

The `install` script remains the single source of truth for all system configuration. ansible-pull simply provides scheduled, pull-based delivery.

Closes #67