### PR TITLE
fix: restrict autoupdate sudoers to least-privilege /usr/bin/pacman only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Use systemctl restart tmp.mount instead of mount -o remount for systemd-managed /tmp
 - sysctl_set no longer aborts when a key is absent from /proc/sys (e.g. kernel.kexec_load_disabled on linux-hardened with CONFIG_KEXEC=n) — persistent config is still written, live apply is skipped with a clear message
 - Detect physical network interface on VMs by matching common prefixes (eth, enp, ens) instead of using 'type ether' filter
+- Restrict autoupdate sudoers to /usr/bin/pacman only instead of unrestricted root access
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script
@@ -54,6 +55,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Use yay -Syyu in auto-update service when yay is installed, falling back to pacman
 - Run auto-update service as markr user when yay is installed; set NOPASSWD sudoers accordingly
 - Replace markr sudoers management with dedicated autoupdate system user (nologin, no home) for yay auto-update
+- autoupdate user always created regardless of whether yay is installed
+- auto-update service always runs as autoupdate user; wrapper uses sudo pacman as fallback when yay is absent
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/install
+++ b/install
@@ -356,53 +356,31 @@ fi
 
 echo "Configuring auto-update service..."
 
-# Detect yay once — drives user creation, service User=, and sudoers policy
-YAY_INSTALLED=0
-[ -x /usr/bin/yay ] && YAY_INSTALLED=1
-
 # ── autoupdate system user ────────────────────────────────────────────────────
-# Only exists when yay is installed. Has no login shell and no home directory
-# so it cannot be used interactively or via SSH.
-# Removed when yay is no longer installed.
-if [ "${YAY_INSTALLED}" = "1" ]; then
-    if id autoupdate > /dev/null 2>&1; then
-        skip "autoupdate user already exists"
-    else
-        useradd --system --no-create-home --shell /usr/sbin/nologin autoupdate \
-            || die "Could not create autoupdate user"
-        ok "autoupdate user created"
-    fi
+# Always present. Has no login shell and no home directory so it cannot be used
+# interactively or via SSH. The service always runs as this user regardless of
+# whether yay or pacman is the active updater.
+if id autoupdate > /dev/null 2>&1; then
+    skip "autoupdate user already exists"
 else
-    if id autoupdate > /dev/null 2>&1; then
-        userdel autoupdate || die "Could not remove autoupdate user"
-        ok "autoupdate user removed (yay not installed)"
-    else
-        skip "autoupdate user not present"
-    fi
+    useradd --system --no-create-home --shell /usr/sbin/nologin autoupdate \
+        || die "Could not create autoupdate user"
+    ok "autoupdate user created"
 fi
 
 # ── sudoers for autoupdate ────────────────────────────────────────────────────
-# NOPASSWD required so yay can call sudo pacman internally without blocking.
-# File is removed when yay is not installed (user also removed above).
+# Restricted to /usr/bin/pacman only. yay calls sudo pacman internally; the
+# pacman-only fallback wrapper also uses sudo pacman. No broad root access needed.
 AUTOUPDATE_SUDOERS="/etc/sudoers.d/autoupdate"
-if [ "${YAY_INSTALLED}" = "1" ]; then
-    AUTOUPDATE_SUDOERS_EXPECTED="autoupdate ALL=(ALL) NOPASSWD: ALL"
-    if [ -f "${AUTOUPDATE_SUDOERS}" ] && [ "$(cat "${AUTOUPDATE_SUDOERS}")" = "${AUTOUPDATE_SUDOERS_EXPECTED}" ]; then
-        skip "sudoers autoupdate already correct"
-    else
-        printf '%s\n' "${AUTOUPDATE_SUDOERS_EXPECTED}" > "${AUTOUPDATE_SUDOERS}" \
-            || die "Could not write ${AUTOUPDATE_SUDOERS}"
-        chmod 440 "${AUTOUPDATE_SUDOERS}" || die "Could not chmod ${AUTOUPDATE_SUDOERS}"
-        visudo -c -f "${AUTOUPDATE_SUDOERS}" || die "Invalid sudoers file ${AUTOUPDATE_SUDOERS}"
-        ok "sudoers autoupdate written"
-    fi
+AUTOUPDATE_SUDOERS_EXPECTED="autoupdate ALL=(ALL) NOPASSWD: /usr/bin/pacman"
+if [ -f "${AUTOUPDATE_SUDOERS}" ] && [ "$(cat "${AUTOUPDATE_SUDOERS}")" = "${AUTOUPDATE_SUDOERS_EXPECTED}" ]; then
+    skip "sudoers autoupdate already correct"
 else
-    if [ -f "${AUTOUPDATE_SUDOERS}" ]; then
-        rm "${AUTOUPDATE_SUDOERS}" || die "Could not remove ${AUTOUPDATE_SUDOERS}"
-        ok "sudoers autoupdate removed (yay not installed)"
-    else
-        skip "sudoers autoupdate not present"
-    fi
+    printf '%s\n' "${AUTOUPDATE_SUDOERS_EXPECTED}" > "${AUTOUPDATE_SUDOERS}" \
+        || die "Could not write ${AUTOUPDATE_SUDOERS}"
+    chmod 440 "${AUTOUPDATE_SUDOERS}" || die "Could not chmod ${AUTOUPDATE_SUDOERS}"
+    visudo -c -f "${AUTOUPDATE_SUDOERS}" || die "Invalid sudoers file ${AUTOUPDATE_SUDOERS}"
+    ok "sudoers autoupdate written"
 fi
 
 # ── legacy 01_markr sudoers cleanup ──────────────────────────────────────────
@@ -420,7 +398,7 @@ AUTO_UPDATE_SCRIPT_EXPECTED=$(cat << 'EOF'
 if [ -x /usr/bin/yay ]; then
     exec yay -Syyu --noconfirm
 else
-    exec pacman -Syyu --noconfirm
+    exec sudo pacman -Syyu --noconfirm
 fi
 EOF
 )
@@ -434,11 +412,10 @@ else
 fi
 
 # ── service unit ──────────────────────────────────────────────────────────────
-# Run as autoupdate (nologin system user) when yay is installed so yay does not
-# run as root. Fall back to root when only pacman is used.
+# Always run as autoupdate (nologin system user). The wrapper uses sudo pacman
+# when yay is not installed, so root is never needed directly.
 AUTO_UPDATE_SERVICE="/etc/systemd/system/auto-update.service"
-if [ "${YAY_INSTALLED}" = "1" ]; then
-    AUTO_UPDATE_SERVICE_EXPECTED=$(cat << 'EOF'
+AUTO_UPDATE_SERVICE_EXPECTED=$(cat << 'EOF'
 [Unit]
 Description=Run arch-update auto check
 After=network-online.target
@@ -449,18 +426,6 @@ User=autoupdate
 ExecStart=/usr/local/bin/auto-update
 EOF
 )
-else
-    AUTO_UPDATE_SERVICE_EXPECTED=$(cat << 'EOF'
-[Unit]
-Description=Run arch-update auto check
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/auto-update
-EOF
-)
-fi
 if [ -f "${AUTO_UPDATE_SERVICE}" ] && [ "$(cat "${AUTO_UPDATE_SERVICE}")" = "${AUTO_UPDATE_SERVICE_EXPECTED}" ]; then
     skip "auto-update.service already correct"
 else


### PR DESCRIPTION
## Summary

Restricts the `autoupdate` sudoers entry from unrestricted `NOPASSWD: ALL` to `NOPASSWD: /usr/bin/pacman` only. Also simplifies the auto-update setup so it always uses the `autoupdate` user (no root fallback).

### Changes
- Replace `NOPASSWD: ALL` with `NOPASSWD: /usr/bin/pacman` — yay calls `sudo pacman` internally so this is sufficient
- Always create the `autoupdate` system user regardless of whether yay is installed
- Always run `auto-update.service` as `User=autoupdate` (remove the conditional root fallback)
- Update wrapper script fallback from `exec pacman` to `exec sudo pacman` to work under the restricted sudoers rule
- Remove the now-unused `YAY_INSTALLED` variable

Closes #51