### PR TITLE
fix: correct sshd config filename typo logingraceime → loginGraceTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - sysctl_set no longer aborts when a key is absent from /proc/sys (e.g. kernel.kexec_load_disabled on linux-hardened with CONFIG_KEXEC=n) — persistent config is still written, live apply is skipped with a clear message
 - Detect physical network interface on VMs by matching common prefixes (eth, enp, ens) instead of using 'type ether' filter
 - Restrict autoupdate sudoers to /usr/bin/pacman only instead of unrestricted root access
+- Corrected typo in sshd config filename logingraceime to loginGraceTime and clean up old misnamed file
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -215,6 +215,16 @@ sshd_set() {
 
 mkdir -p /etc/ssh/sshd_config.d
 
+# Remove legacy misnamed sshd config file (logingraceime → loginGraceTime typo fix)
+SSHD_LEGACY_GRACETIME="/etc/ssh/sshd_config.d/10-logingraceime.conf"
+if [ -f "${SSHD_LEGACY_GRACETIME}" ]; then
+    rm "${SSHD_LEGACY_GRACETIME}" || die "Could not remove ${SSHD_LEGACY_GRACETIME}"
+    SSHD_CHANGED=1
+    ok "Removed legacy misnamed sshd config file: 10-logingraceime.conf"
+else
+    skip "No legacy misnamed sshd config file present"
+fi
+
 # Host keys
 sshd_set "hostkey-ed25519"          HostKey                  /etc/ssh/ssh_host_ed25519_key
 sshd_set "hostkey-rsa"              HostKey                  /etc/ssh/ssh_host_rsa_key
@@ -260,7 +270,7 @@ sshd_set "loglevel"                 LogLevel                 VERBOSE
 # Rate limiting and access
 sshd_set "maxauthtries"             MaxAuthTries             3
 sshd_set "maxsessions"              MaxSessions              3
-sshd_set "logingraceime"            LoginGraceTime           30
+sshd_set "loginGraceTime"           LoginGraceTime           30
 
 # Disable unsafe features
 sshd_set "hostbasedauthentication"  HostbasedAuthentication  no


### PR DESCRIPTION
## Summary

Fixes a typo in the sshd configuration setup where the first argument to `sshd_set` was `logingraceime` (missing `T`) instead of `loginGraceTime`. This caused the drop-in config file to be created as `/etc/ssh/sshd_config.d/10-logingraceime.conf` instead of the correct `/etc/ssh/sshd_config.d/10-loginGraceTime.conf`.

The SSH configuration itself was functionally correct (sshd reads all files in the directory regardless of name), but the filename was inconsistent with the naming convention used by all other entries.

### Changes

- Corrected the first argument to `sshd_set` from `"logingraceime"` to `"loginGraceTime"`
- Added a cleanup block to remove the legacy `10-logingraceime.conf` file on systems where the script has already been run with the old typo

Closes #52