### PR TITLE
fix: correct RFC 1918 firewalld CIDR for 172.16.0.0 range from /20 to /12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Detect physical network interface on VMs by matching common prefixes (eth, enp, ens) instead of using 'type ether' filter
 - Restrict autoupdate sudoers to /usr/bin/pacman only instead of unrestricted root access
 - Corrected typo in sshd config filename logingraceime to loginGraceTime and clean up old misnamed file
+- Correct RFC 1918 firewalld CIDR for 172.16.0.0 range from /20 to /12 and remove any legacy /20 rules
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -149,7 +149,15 @@ FIREWALLD_CHANGED=0
 firewalld_allow_private() {
     _fw_proto="${1}"
     _fw_port="${2}"
-    for _fw_cidr in "10.0.0.0/8" "192.168.0.0/16" "172.16.0.0/20"; do
+    # Remove legacy incorrect 172.16.0.0/20 rule if present (RFC 1918 range is /12)
+    _fw_legacy_rule="rule family=\"ipv4\" source address=\"172.16.0.0/20\" port protocol=\"${_fw_proto}\" port=\"${_fw_port}\" accept"
+    if firewall-cmd --permanent --query-rich-rule="${_fw_legacy_rule}" > /dev/null 2>&1; then
+        firewall-cmd --permanent --remove-rich-rule="${_fw_legacy_rule}" \
+            || die "Could not remove legacy firewalld rule for ${_fw_proto}/${_fw_port} from 172.16.0.0/20"
+        ok "firewalld: removed legacy ${_fw_proto}/${_fw_port} rule for 172.16.0.0/20"
+        FIREWALLD_CHANGED=1
+    fi
+    for _fw_cidr in "10.0.0.0/8" "192.168.0.0/16" "172.16.0.0/12"; do
         _fw_rule="rule family=\"ipv4\" source address=\"${_fw_cidr}\" port protocol=\"${_fw_proto}\" port=\"${_fw_port}\" accept"
         if firewall-cmd --permanent --query-rich-rule="${_fw_rule}" > /dev/null 2>&1; then
             skip "firewalld: ${_fw_proto}/${_fw_port} from ${_fw_cidr} already allowed"


### PR DESCRIPTION
## Summary

The `firewalld_allow_private` function used `172.16.0.0/20` as the CIDR for the 172.16.x.x RFC 1918 private range. This only covers `172.16.0.0–172.16.15.255`, excluding hosts such as `172.17.x.x`, `172.24.x.x`, and `172.31.x.x` — meaning SSH from most of the 172.16.0.0/12 range was incorrectly blocked.

The correct RFC 1918 range is `172.16.0.0/12` (covering `172.16.0.0–172.31.255.255`).

## Changes

- Fixed the CIDR in `firewalld_allow_private` from `172.16.0.0/20` to `172.16.0.0/12`
- Added idempotent cleanup: on systems where the script has already run, the legacy `/20` rich rule is automatically removed and replaced with the correct `/12` rule

Closes #53