### PR TITLE
fix: consolidate Docker restarts to avoid double restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Restrict autoupdate sudoers to /usr/bin/pacman only instead of unrestricted root access
 - Corrected typo in sshd config filename logingraceime to loginGraceTime and clean up old misnamed file
 - Correct RFC 1918 firewalld CIDR for 172.16.0.0 range from /20 to /12 and remove any legacy /20 rules
+- Consolidate Docker restarts to avoid restarting twice when both daemon.json and legacy drop-in change
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -129,7 +129,7 @@ if [ -f "${DOCKER_DROPIN}" ]; then
     rm "${DOCKER_DROPIN}" || die "Could not remove ${DOCKER_DROPIN}"
     rmdir "$(dirname "${DOCKER_DROPIN}")" 2>/dev/null || true
     systemctl daemon-reload || die "Could not reload systemd daemon"
-    systemctl restart docker || die "Could not restart docker.service"
+    RESTART=1
     ok "Removed legacy Docker systemd security drop-in"
 else
     skip "No legacy Docker systemd security drop-in present"


### PR DESCRIPTION
## Problem

When both `daemon.json` changes **and** the legacy drop-in removal are triggered in the same run, Docker was being restarted twice:

1. Immediately inside the drop-in removal block (`systemctl restart docker`)
2. Again at the end of the script via the `RESTART=1` flag (`[ "$RESTART" = "1" ] && systemctl restart docker`)

## Fix

The drop-in removal block now sets `RESTART=1` instead of restarting Docker directly. This consolidates all Docker restarts to the single call at the end of the script, ensuring Docker is restarted at most once per run regardless of which conditions are triggered.

Closes #54