### PR TITLE
fix: add umask hardening via /etc/profile.d/umask.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - install script creates a security script in the current working directory
 - Install ansible and configure ansible-pull systemd timer to automatically apply latest system configuration every 6 hours, replacing the manual security script
 - Add site.yml Ansible playbook entry point for ansible-pull
+- Harden default umask to 027 via /etc/profile.d/umask.sh
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -726,6 +726,29 @@ else
 fi
 
 # ============================================================
+# Harden default umask via /etc/profile.d
+# ============================================================
+
+# Sets a restrictive default umask (027) for all login shells:
+#   files: 640 (owner rw, group r, others none)
+#   dirs:  750 (owner rwx, group rx, others none)
+# This reduces the risk of newly created files being world-readable.
+echo "Configuring umask hardening..."
+UMASK_PROFILE="/etc/profile.d/umask.sh"
+UMASK_EXPECTED=$(cat << 'EOF'
+#!/bin/sh
+umask 027
+EOF
+)
+if [ -f "${UMASK_PROFILE}" ] && [ "$(cat "${UMASK_PROFILE}")" = "${UMASK_EXPECTED}" ]; then
+    skip "umask profile already correct"
+else
+    printf '%s\n' "${UMASK_EXPECTED}" > "${UMASK_PROFILE}" || die "Could not write ${UMASK_PROFILE}"
+    chmod 644 "${UMASK_PROFILE}" || die "Could not chmod ${UMASK_PROFILE}"
+    ok "umask hardening configured (027)"
+fi
+
+# ============================================================
 # Blacklist unused/dangerous kernel modules
 # ============================================================
 


### PR DESCRIPTION
## Summary

Sets a restrictive default umask (027) for all login shells by adding `/etc/profile.d/umask.sh`.

The default Arch Linux umask of 022 makes newly created files world-readable (644) and directories world-traversable (755). A umask of 027 restricts new files to 640 (owner rw, group r, others none) and directories to 750 (owner rwx, group rx, others none), reducing the risk of sensitive files being accidentally world-readable.

The step is idempotent — if the file already has the correct content it is skipped.

Closes #55