### PR TITLE
feat: install and configure AppArmor profiles to match GRUB LSM params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Install ansible and configure ansible-pull systemd timer to automatically apply latest system configuration every 6 hours, replacing the manual security script
 - Add site.yml Ansible playbook entry point for ansible-pull
 - Harden default umask to 027 via /etc/profile.d/umask.sh
+- Install and enable AppArmor service with community profiles enforced for sshd, docker-default, and fail2ban
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -629,6 +629,46 @@ if [ "$GRUB_CHANGED" = "1" ]; then
 fi
 
 # ============================================================
+# Configure AppArmor
+# ============================================================
+# The GRUB command line already enables AppArmor as an LSM:
+#   lsm=landlock,lockdown,yama,apparmor,bpf apparmor=1 security=apparmor
+# Install the userspace tools and profiles so the LSM is not loaded empty.
+
+echo "Configuring AppArmor..."
+pacman -S --noconfirm --needed apparmor || die "Could not install apparmor"
+systemctl enable --now apparmor || die "Could not enable apparmor"
+ok "AppArmor service enabled"
+
+# Install community-maintained profiles if available (may come from Chaotic AUR)
+if pacman -Qq apparmor-profiles > /dev/null 2>&1; then
+    skip "apparmor-profiles already installed"
+else
+    if pacman -S --noconfirm --needed apparmor-profiles 2>/dev/null; then
+        ok "apparmor-profiles installed"
+    else
+        skip "apparmor-profiles not available in repos — continuing without community profiles"
+    fi
+fi
+
+# Enforce AppArmor profiles for services configured by this script.
+# Only profiles whose files are present on disk are enforced; missing profiles are skipped.
+for _aa_profile in sshd docker-default fail2ban; do
+    _aa_file="/etc/apparmor.d/${_aa_profile}"
+    if [ ! -f "${_aa_file}" ]; then
+        skip "AppArmor: no profile found for ${_aa_profile}"
+        continue
+    fi
+    if aa-status 2>/dev/null | grep -qF "   ${_aa_profile}"; then
+        skip "AppArmor: ${_aa_profile} already in enforce mode"
+    else
+        aa-enforce "${_aa_file}" || die "Could not enforce AppArmor profile ${_aa_profile}"
+        ok "AppArmor: ${_aa_profile} profile enforced"
+    fi
+done
+unset _aa_profile _aa_file
+
+# ============================================================
 # Configure sysctl hardening
 # ============================================================
 


### PR DESCRIPTION
## Summary

The GRUB kernel command line already enables AppArmor as an LSM (`apparmor=1 security=apparmor lsm=...apparmor...`), but no AppArmor userspace package or profiles were installed. This means the LSM was loaded but had no policies to enforce, providing no actual confinement.

## Changes

- Install `apparmor` package via pacman
- Enable `apparmor` systemd service (`systemctl enable --now apparmor`)
- Install `apparmor-profiles` community profiles if available (Arch repos / Chaotic AUR), skipping gracefully if not
- Enforce AppArmor profiles for `sshd`, `docker-default`, and `fail2ban` — all services configured by this script
- All steps are idempotent: skipped if already enforced or profile absent

Closes #56