### PR TITLE
fix: enable post-quantum key exchange algorithms in SSH server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Corrected typo in sshd config filename logingraceime to loginGraceTime and clean up old misnamed file
 - Correct RFC 1918 firewalld CIDR for 172.16.0.0 range from /20 to /12 and remove any legacy /20 rules
 - Consolidate Docker restarts to avoid restarting twice when both daemon.json and legacy drop-in change
+- Enable post-quantum key exchange algorithms (mlkem768x25519-sha256, sntrup761x25519-sha512) in SSH server to prevent store-now-decrypt-later attacks
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -238,7 +238,8 @@ sshd_set "hostkey-ed25519"          HostKey                  /etc/ssh/ssh_host_e
 sshd_set "hostkey-rsa"              HostKey                  /etc/ssh/ssh_host_rsa_key
 
 # Key exchange, ciphers, MACs
-sshd_set "kexalgorithms"            KexAlgorithms            curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512
+# PQ hybrids first (mlkem768x25519-sha256: NIST ML-KEM / OpenSSH 9.9+; sntrup761x25519: OpenSSH 8.5+), then classical fallbacks
+sshd_set "kexalgorithms"            KexAlgorithms            mlkem768x25519-sha256,sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512
 sshd_set "ciphers"                  Ciphers                  chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 sshd_set "macs"                     MACs                     hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 


### PR DESCRIPTION
## Summary

Adds post-quantum hybrid key exchange algorithms to sshd to eliminate the SSH client warning:

> `** WARNING: connection is not using a post-quantum key exchange algorithm.`
> `** This session may be vulnerable to "store now, decrypt later" attacks.`

### Changes

- Prepends `mlkem768x25519-sha256` (NIST ML-KEM standard, OpenSSH 9.9+) and `sntrup761x25519-sha512@openssh.com` (OpenSSH 8.5+) to `KexAlgorithms`
- Classical algorithms (`curve25519-sha256`, `curve25519-sha256@libssh.org`, `diffie-hellman-group16-sha512`) retained as fallbacks for older clients

### References

- https://openssh.com/pq.html

Closes #58