### PR TITLE
feat: install and enable AppArmor with audit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add site.yml Ansible playbook entry point for ansible-pull
 - Harden default umask to 027 via /etc/profile.d/umask.sh
 - Install and enable AppArmor service with community profiles enforced for sshd, docker-default, and fail2ban
+- Install audit package alongside AppArmor for kernel-level audit logging
+- Enable auditd service for AppArmor audit event logging
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run
@@ -63,6 +65,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace markr sudoers management with dedicated autoupdate system user (nologin, no home) for yay auto-update
 - autoupdate user always created regardless of whether yay is installed
 - auto-update service always runs as autoupdate user; wrapper uses sudo pacman as fallback when yay is absent
+- Add integrity LSM to GRUB lsm= kernel parameter for IMA support alongside AppArmor
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/install
+++ b/install
@@ -598,7 +598,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0"
+GRUB_PARAMS="panic=20 slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions
@@ -611,6 +611,20 @@ fi
 # Extract current value and build new value in memory, checking only within GRUB_CMDLINE_LINUX
 CMDLINE=$(sed -n 's/^GRUB_CMDLINE_LINUX="\(.*\)"$/\1/p' /etc/default/grub)
 NEW_CMDLINE="$CMDLINE"
+
+# Migrate lsm= to include integrity if the parameter is already set without it
+_lsm_current=$(printf '%s\n' "$NEW_CMDLINE" | tr ' ' '\n' | grep '^lsm=' | sed 's/^lsm=//')
+if [ -n "$_lsm_current" ]; then
+    case "$_lsm_current" in
+        *integrity*) skip "GRUB: lsm already contains integrity" ;;
+        *)
+            NEW_CMDLINE=$(printf '%s\n' "$NEW_CMDLINE" | sed "s|lsm=${_lsm_current}|lsm=landlock,lockdown,yama,integrity,apparmor,bpf|")
+            GRUB_CHANGED=1
+            ok "GRUB: updated lsm= to include integrity"
+            ;;
+    esac
+fi
+unset _lsm_current
 
 for PARAM in $GRUB_PARAMS; do
     PARAM_KEY="${PARAM%%=*}"
@@ -633,13 +647,16 @@ fi
 # Configure AppArmor
 # ============================================================
 # The GRUB command line already enables AppArmor as an LSM:
-#   lsm=landlock,lockdown,yama,apparmor,bpf apparmor=1 security=apparmor
+#   lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor
 # Install the userspace tools and profiles so the LSM is not loaded empty.
+# The audit package provides the auditd daemon for AppArmor audit logging.
 
 echo "Configuring AppArmor..."
-pacman -S --noconfirm --needed apparmor || die "Could not install apparmor"
+pacman -S --noconfirm --needed apparmor audit || die "Could not install apparmor and audit"
 systemctl enable --now apparmor || die "Could not enable apparmor"
 ok "AppArmor service enabled"
+systemctl enable --now auditd || die "Could not enable auditd"
+ok "auditd enabled for AppArmor audit logging"
 
 # Install community-maintained profiles if available (may come from Chaotic AUR)
 if pacman -Qq apparmor-profiles > /dev/null 2>&1; then


### PR DESCRIPTION
## Overview

Implements issue #59: Install and enable AppArmor with full audit logging support.

## Changes

- **GRUB kernel parameter**: Added `integrity` to the `lsm=` parameter (`lsm=landlock,lockdown,yama,integrity,apparmor,bpf`) to enable IMA (Integrity Measurement Architecture) alongside AppArmor and other LSMs
- **Migration logic**: Detects existing installations where `lsm=` is set without `integrity` and upgrades the value automatically
- **audit package**: Added `audit` to the AppArmor package install step so AppArmor audit events are captured by the kernel audit subsystem
- **auditd service**: Enabled `auditd` service for AppArmor audit event logging

## Notes

- AppArmor installation and service enable were already present; this PR completes the setup by adding the `integrity` LSM and audit infrastructure
- Migration is idempotent: systems already having `integrity` in `lsm=` will emit a `skip` message
- All shellcheck checks pass

Closes #59