### PR TITLE
fix: Ensure sshd host keys are generated before SSH configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Correct RFC 1918 firewalld CIDR for 172.16.0.0 range from /20 to /12 and remove any legacy /20 rules
 - Consolidate Docker restarts to avoid restarting twice when both daemon.json and legacy drop-in change
 - Enable post-quantum key exchange algorithms (mlkem768x25519-sha256, sntrup761x25519-sha512) in SSH server to prevent store-now-decrypt-later attacks
+- Ensure sshd host keys are generated before SSH configuration on fresh installs
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -209,6 +209,16 @@ fi
 echo "Configuring SSH hardening..."
 SSHD_CHANGED=0
 
+# Ensure sshd host keys exist before configuring or validating sshd
+# On a fresh install, sshd may never have been started so keys are absent.
+# ssh-keygen -A generates all missing host key types without overwriting existing ones.
+if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+    ssh-keygen -A || die "Could not generate sshd host keys"
+    ok "sshd host keys generated"
+else
+    skip "sshd host keys already present"
+fi
+
 sshd_set() {
     file="/etc/ssh/sshd_config.d/10-${1}.conf"
     expected="${2} ${3}"


### PR DESCRIPTION
On a fresh Arch Linux VM, sshd may never have been started, meaning the host keys in `/etc/ssh/` have not been generated yet. The `sshd -t` config validation fails without host keys present.

This fix adds a check before any SSH configuration: if `/etc/ssh/ssh_host_ed25519_key` does not exist, `ssh-keygen -A` is called to generate all missing host key types. This is idempotent — on subsequent runs the keys already exist and the step is skipped.

Closes #61