### PR TITLE
fix: consolidate all unconditional pacman installs into a single sorted call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - autoupdate user always created regardless of whether yay is installed
 - auto-update service always runs as autoupdate user; wrapper uses sudo pacman as fallback when yay is absent
 - Add integrity LSM to GRUB lsm= kernel parameter for IMA support alongside AppArmor
+- Consolidated all unconditional pacman package installs into a single sorted call
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/install
+++ b/install
@@ -70,7 +70,22 @@ case "$(uname -r)" in
 esac
 
 echo "Installing packages..."
-pacman -S --noconfirm --needed docker docker-compose docker-buildx git firewalld fail2ban pkgstats reflector pacman-contrib openssh logrotate ansible || die "Could not install packages"
+pacman -S --noconfirm --needed \
+    ansible \
+    apparmor \
+    audit \
+    docker \
+    docker-buildx \
+    docker-compose \
+    fail2ban \
+    firewalld \
+    git \
+    logrotate \
+    openssh \
+    pacman-contrib \
+    pkgstats \
+    reflector \
+    || die "Could not install packages"
 ok "Packages installed"
 
 # ============================================================
@@ -708,7 +723,6 @@ fi
 # The audit package provides the auditd daemon for AppArmor audit logging.
 
 echo "Configuring AppArmor..."
-pacman -S --noconfirm --needed apparmor audit || die "Could not install apparmor and audit"
 systemctl enable --now apparmor || die "Could not enable apparmor"
 ok "AppArmor service enabled"
 systemctl enable --now auditd || die "Could not enable auditd"


### PR DESCRIPTION
Consolidates the two separate unconditional `pacman -S --needed --noconfirm` calls into a single alphabetically-sorted list near the top of the install script.

**Before:** packages were split across two calls:
- Line ~73: `docker docker-compose docker-buildx git firewalld fail2ban pkgstats reflector pacman-contrib openssh logrotate ansible`
- Line ~711 (AppArmor section): `apparmor audit`

**After:** a single consolidated, sorted install:
```
ansible apparmor audit docker docker-buildx docker-compose fail2ban firewalld git logrotate openssh pacman-contrib pkgstats reflector
```

The conditional `apparmor-profiles` install (tries Chaotic AUR, skips if unavailable) is left in place as it is conditional by design.

Closes #82