### PR TITLE
fix: Disable TCP timestamps to reduce information leakage and fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - change rp_filter from strict (1) to loose (2) to allow Docker container routing; persist net.ipv4.ip_forward=1 so container traffic survives sysctl reloads
 - net.bridge.bridge-nf-call-iptables corrected to 1 (was incorrectly set to 0 in #111) — value 1 enables iptables filtering on bridged traffic, required for Docker networking rules to apply to container traffic
 - Docker daemon.json: set firewall-backend to nftables so Docker uses nftables for its NAT/filtering rules, consistent with the system firewall (firewalld running in nftables mode)
+- Clarify TCP timestamps comment: document PAWS-bypass mitigation and relationship with net.ipv4.tcp_rfc1337=1
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -807,7 +807,8 @@ sysctl_set vm.mmap_rnd_compat_bits                  16
 sysctl_set kernel.sysrq                             0
 sysctl_set net.ipv4.tcp_syncookies                  1
 sysctl_set net.ipv4.tcp_rfc1337                     1
-# Disable TCP timestamps to prevent uptime/fingerprinting leakage (RFC 1323 optional feature)
+# Disable TCP timestamps to prevent uptime-based fingerprinting and PAWS-bypass techniques;
+# net.ipv4.tcp_rfc1337=1 above provides partial mitigation for TIME-WAIT assassination.
 # Reference: https://obscurix.github.io/security/kernel-hardening.html
 sysctl_set net.ipv4.tcp_timestamps                  0
 # Loose reverse-path filtering (2) instead of strict (1): strict mode drops packets on


### PR DESCRIPTION
Adds `net.ipv4.tcp_timestamps=0` sysctl to the kernel hardening section.

TCP timestamps (RFC 1323) expose system uptime and allow remote hosts to fingerprint the OS. They have also been involved in PAWS bypass techniques. Disabling them reduces the information leakage surface with minimal functional impact on a VM network environment.

The existing `net.ipv4.tcp_rfc1337=1` setting provides partial mitigation for TIME-WAIT assassination, which partially compensates for the loss of PAWS protection.

Closes #85