### PR TITLE
feat: Disable TCP SACK to reduce remote kernel exploit surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Persist net.ipv6.conf.all.forwarding=1 and net.ipv6.conf.default.forwarding=1 for routed Docker/VM traffic
 - Block newly connected USB devices after boot via kernel.deny_new_usb=1 to prevent BadUSB attacks on a headless server VM
 - Add mitigations=auto to GRUB to explicitly enable all applicable CPU vulnerability mitigations (Spectre, Meltdown, MDS, etc.)
+- Disable TCP SACK (net.ipv4.tcp_sack=0) to reduce remote kernel exploit surface (CVE-2019-11477, CVE-2019-11478, CVE-2019-11479)
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -862,6 +862,13 @@ sysctl_set kernel.perf_event_paranoid               3
 # Reference: https://obscurix.github.io/security/kernel-hardening.html
 sysctl_set kernel.deny_new_usb                      1
 
+# Disable TCP SACK (Selective Acknowledgment) — a history of critical remote kernel
+# vulnerabilities (CVE-2019-11477, CVE-2019-11478, CVE-2019-11479). On a VM with
+# reliable datacenter networking the performance trade-off of full-window retransmits
+# on packet loss is negligible.
+# Reference: https://obscurix.github.io/security/kernel-hardening.html
+sysctl_set net.ipv4.tcp_sack                        0
+
 if [ "$SYSCTL_CHANGED" = "1" ]; then
     sysctl --system || die "Could not apply sysctl settings"
     ok "sysctl settings applied"


### PR DESCRIPTION
Disable TCP Selective Acknowledgment (`net.ipv4.tcp_sack=0`) to eliminate the attack surface exploited in:
- CVE-2019-11477 (SACK Panic)
- CVE-2019-11478 (SACK Slowness)
- CVE-2019-11479

TCP SACK has a history of critical remote kernel vulnerabilities. On a server VM with reliable datacenter networking, SACK provides minimal performance benefit and the trade-off (full-window retransmits on packet loss) is negligible.

Reference: https://obscurix.github.io/security/kernel-hardening.html

Closes #86