### PR TITLE
feat: Enable IOMMU in GRUB for DMA protection against malicious devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add mce=0 to GRUB to panic immediately on uncorrectable hardware memory errors
 - Disable TCP SACK (net.ipv4.tcp_sack=0) to reduce remote kernel exploit surface (CVE-2019-11477, CVE-2019-11478, CVE-2019-11479)
 - Enable IOMMU in GRUB (intel_iommu=on, amd_iommu=on, iommu=force) to provide DMA protection against malicious devices
+- Add oops=panic to GRUB to cause an immediate kernel panic on any kernel oops, preventing post-oops exploitation
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add mitigations=auto to GRUB to explicitly enable all applicable CPU vulnerability mitigations (Spectre, Meltdown, MDS, etc.)
 - Add mce=0 to GRUB to panic immediately on uncorrectable hardware memory errors
 - Disable TCP SACK (net.ipv4.tcp_sack=0) to reduce remote kernel exploit surface (CVE-2019-11477, CVE-2019-11478, CVE-2019-11479)
+- Enable IOMMU in GRUB (intel_iommu=on, amd_iommu=on, iommu=force) to provide DMA protection against malicious devices
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -678,7 +678,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 mce=0 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1 intel_iommu=on amd_iommu=on iommu=force"
+GRUB_PARAMS="panic=20 mce=0 oops=panic mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1 intel_iommu=on amd_iommu=on iommu=force"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions

--- a/install
+++ b/install
@@ -678,7 +678,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 mce=0 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
+GRUB_PARAMS="panic=20 mce=0 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1 intel_iommu=on amd_iommu=on iommu=force"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions


### PR DESCRIPTION
Add `intel_iommu=on`, `amd_iommu=on`, and `iommu=force` to `GRUB_CMDLINE_LINUX`.

IOMMU provides hardware-enforced isolation of DMA operations, preventing malicious or compromised peripherals from reading/writing arbitrary memory.

- `intel_iommu=on` — enables IOMMU on Intel CPUs
- `amd_iommu=on` — enables IOMMU on AMD CPUs (including both is safe; the non-applicable one is ignored)
- `iommu=force` — disables the IOMMU bypass for devices that claim DMA coherency (closes a potential bypass vector)

Docker-compatible: IOMMU does not affect container networking or namespaces.

Reference: https://obscurix.github.io/security/kernel-hardening.html

Closes #88