### PR TITLE
feat: Add oops=panic to GRUB to prevent exploitation of a corrupted kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add mitigations=auto to GRUB to explicitly enable all applicable CPU vulnerability mitigations (Spectre, Meltdown, MDS, etc.)
 - Add mce=0 to GRUB to panic immediately on uncorrectable hardware memory errors
 - Disable TCP SACK (net.ipv4.tcp_sack=0) to reduce remote kernel exploit surface (CVE-2019-11477, CVE-2019-11478, CVE-2019-11479)
+- Add oops=panic to GRUB to cause an immediate kernel panic on any kernel oops, preventing post-oops exploitation
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -678,7 +678,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 mce=0 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
+GRUB_PARAMS="panic=20 mce=0 oops=panic mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions


### PR DESCRIPTION
Add `oops=panic` to `GRUB_CMDLINE_LINUX`.

When the kernel encounters a non-fatal error (an "oops"), it normally logs it and continues running in a potentially compromised state. An attacker can trigger an oops to put the kernel into a state they can further exploit.

Setting `oops=panic` causes the system to immediately panic on any kernel oops, triggering a reboot via the existing `panic=20` parameter. This prevents post-oops exploitation.

Docker-compatible: does not affect container networking or namespaces.

References:
- https://obscurix.github.io/security/kernel-hardening.html
- https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

Closes #89