### PR TITLE
feat: Add mce=0 to GRUB to panic on uncorrectable hardware errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Persist net.ipv6.conf.all.forwarding=1 and net.ipv6.conf.default.forwarding=1 for routed Docker/VM traffic
 - Block newly connected USB devices after boot via kernel.deny_new_usb=1 to prevent BadUSB attacks on a headless server VM
 - Add mitigations=auto to GRUB to explicitly enable all applicable CPU vulnerability mitigations (Spectre, Meltdown, MDS, etc.)
+- Add mce=0 to GRUB to panic immediately on uncorrectable hardware memory errors
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -678,7 +678,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
+GRUB_PARAMS="panic=20 mce=0 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions


### PR DESCRIPTION
Add `mce=0` to `GRUB_CMDLINE_LINUX`.

Machine Check Exceptions (MCE) are hardware error notifications from the CPU. Uncorrectable MCEs indicate serious hardware failures (e.g. memory corruption). By default the kernel may attempt to continue running; `mce=0` causes an immediate panic, preventing further data corruption or security compromise from corrupted memory.

The system reboots automatically via the existing `panic=20` parameter.

Docker-compatible: does not affect container networking or namespaces.

References:
- https://obscurix.github.io/security/kernel-hardening.html
- https://www.kernel.org/doc/html/latest/arch/x86/x86_64/machinecheck.html

Closes #90