### PR TITLE
feat: Add CPU vulnerability mitigations to GRUB (mitigations=auto)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Improve ASLR entropy via vm.mmap_rnd_bits=32 and vm.mmap_rnd_compat_bits=16
 - Persist net.ipv6.conf.all.forwarding=1 and net.ipv6.conf.default.forwarding=1 for routed Docker/VM traffic
 - Block newly connected USB devices after boot via kernel.deny_new_usb=1 to prevent BadUSB attacks on a headless server VM
+- Add mitigations=auto to GRUB to explicitly enable all applicable CPU vulnerability mitigations (Spectre, Meltdown, MDS, etc.)
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -678,7 +678,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
+GRUB_PARAMS="panic=20 mitigations=auto slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions


### PR DESCRIPTION
Add `mitigations=auto` to `GRUB_CMDLINE_LINUX` to explicitly enable all applicable CPU hardware vulnerability mitigations (Spectre, Meltdown, MDS, TAA, SRBDS, etc.).

`linux-hardened` already applies conservative defaults, but making this explicit ensures mitigations remain active even if kernel defaults change.

`mitigations=auto,nosmt` (disabling hyperthreading) was evaluated but not implemented — the ~30-50% performance trade-off is disproportionate for a Proxmox VM workload.

Docker-compatible: CPU mitigations do not affect container networking or namespaces.

References:
- https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/index.html
- https://wiki.archlinux.org/title/Security#CPU_vulnerabilities_mitigations

Closes #91