### PR TITLE
feat: Block newly connected USB devices via kernel.deny_new_usb sysctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enforce signed kernel modules via module.sig_enforce=1 GRUB parameter to prevent loading of unsigned modules
 - Improve ASLR entropy via vm.mmap_rnd_bits=32 and vm.mmap_rnd_compat_bits=16
 - Persist net.ipv6.conf.all.forwarding=1 and net.ipv6.conf.default.forwarding=1 for routed Docker/VM traffic
+- Block newly connected USB devices after boot via kernel.deny_new_usb=1 to prevent BadUSB attacks on a headless server VM
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -853,6 +853,15 @@ sysctl_set net.ipv4.conf.default.log_martians       1
 # Reference: https://www.kernel.org/doc/html/latest/admin-guide/perf-security.html
 sysctl_set kernel.perf_event_paranoid               3
 
+# Block newly connected USB devices after boot to prevent BadUSB attacks and
+# physical access exploitation. After boot there is no legitimate reason to
+# connect new USB devices to a headless server VM. The sysctl_set helper
+# handles absent sysctls gracefully (linux-hardened may or may not expose this).
+# The usb_storage module is already blacklisted; this provides kernel-level
+# enforcement regardless of module state.
+# Reference: https://obscurix.github.io/security/kernel-hardening.html
+sysctl_set kernel.deny_new_usb                      1
+
 if [ "$SYSCTL_CHANGED" = "1" ]; then
     sysctl --system || die "Could not apply sysctl settings"
     ok "sysctl settings applied"


### PR DESCRIPTION
Set `kernel.deny_new_usb=1` to block USB devices connected after boot at the kernel level, preventing BadUSB attacks (malicious USB devices impersonating keyboards/network cards) and physical access exploitation.

On a headless Proxmox server VM there is no legitimate reason to connect new USB devices during operation. The `usb_storage` module is already blacklisted by the install script; this provides kernel-level enforcement regardless of module state.

The existing `sysctl_set` helper handles absent sysctls gracefully — if `linux-hardened` does not expose this key on a given kernel version, the setting is written persistently but noted as not present in the running kernel.

Docker-compatible: USB is not used by Docker containers.

References:
- https://obscurix.github.io/security/kernel-hardening.html
- https://github.com/anthraxx/linux-hardened

Closes #92