### PR TITLE
feat: Enforce signed kernel modules via module.sig_enforce=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Install audit package alongside AppArmor for kernel-level audit logging
 - Enable auditd service for AppArmor audit event logging
 - Remove orphaned packages inline after package install step rather than via a systemd timer
+- Enforce signed kernel modules via module.sig_enforce=1 GRUB parameter to prevent loading of unsigned modules
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -669,7 +669,7 @@ systemctl enable --now logrotate.timer || die "Could not enable logrotate.timer"
 ok "logrotate timer enabled"
 
 echo "Configuring GRUB kernel command line..."
-GRUB_PARAMS="panic=20 slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0"
+GRUB_PARAMS="panic=20 slab_nomerge slub_debug=FZ init_on_alloc=1 init_on_free=1 pti=on lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor=1 security=apparmor lockdown=confidentiality hardened_usercopy=on ia32_emulation=0 module.sig_enforce=1"
 GRUB_CHANGED=0
 
 # Fix typo from earlier versions


### PR DESCRIPTION
Add `module.sig_enforce=1` to `GRUB_CMDLINE_LINUX`.

This requires all loadable kernel modules to be signed with a trusted key, preventing loading of unsigned or maliciously-crafted kernel modules even by root.

`lockdown=confidentiality` (already set) implies module signature checks, but explicit `module.sig_enforce=1` provides defence-in-depth at the boot parameter level, independently of the LSM stack. No DKMS or out-of-tree modules are used on this system — only official `linux-hardened` kernel modules from the Arch repos.

Docker-compatible: container networking does not require unsigned kernel modules.

References:
- https://obscurix.github.io/security/kernel-hardening.html
- https://wiki.archlinux.org/title/Signed_kernel_modules
- https://www.kernel.org/doc/html/latest/admin-guide/module-signing.html

Closes #93