### PR TITLE
feat: Improve ASLR entropy via vm.mmap_rnd_bits and vm.mmap_rnd_compat_bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable auditd service for AppArmor audit event logging
 - Remove orphaned packages inline after package install step rather than via a systemd timer
 - Enforce signed kernel modules via module.sig_enforce=1 GRUB parameter to prevent loading of unsigned modules
+- Improve ASLR entropy via vm.mmap_rnd_bits=32 and vm.mmap_rnd_compat_bits=16
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -791,6 +791,10 @@ sysctl_set kernel.kexec_load_disabled               1
 sysctl_set kernel.kptr_restrict                     2
 sysctl_set kernel.yama.ptrace_scope                 2
 sysctl_set kernel.randomize_va_space                2
+# Maximise ASLR entropy for 64-bit and 32-bit compat mmap — harder to brute-force bypass.
+# Reference: https://obscurix.github.io/security/kernel-hardening.html
+sysctl_set vm.mmap_rnd_bits                         32
+sysctl_set vm.mmap_rnd_compat_bits                  16
 sysctl_set kernel.sysrq                             0
 sysctl_set net.ipv4.tcp_syncookies                  1
 sysctl_set net.ipv4.tcp_rfc1337                     1


### PR DESCRIPTION
Set `vm.mmap_rnd_bits=32` and `vm.mmap_rnd_compat_bits=16` to maximise ASLR entropy for 64-bit and 32-bit compat mmap respectively.

Higher entropy means more possible memory layouts, making brute-force ASLR bypass significantly harder. These are software-only settings, safe on all x86_64 hardware, and have no impact on Docker networking or namespaces.

References:
- https://obscurix.github.io/security/kernel-hardening.html
- https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html

Closes #84