### PR TITLE
fix: disable TCP timestamps to reduce information leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add idempotency checks to paccache-cleanup service and timer configuration
 - Skip manual reflector.service start when reflector.timer is already active
 - Add idempotency check for reflector.conf configuration
+- Disable TCP timestamps (net.ipv4.tcp_timestamps=0) to prevent uptime leakage and OS fingerprinting
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -794,6 +794,9 @@ sysctl_set kernel.randomize_va_space                2
 sysctl_set kernel.sysrq                             0
 sysctl_set net.ipv4.tcp_syncookies                  1
 sysctl_set net.ipv4.tcp_rfc1337                     1
+# Disable TCP timestamps to prevent uptime/fingerprinting leakage (RFC 1323 optional feature)
+# Reference: https://obscurix.github.io/security/kernel-hardening.html
+sysctl_set net.ipv4.tcp_timestamps                  0
 sysctl_set net.ipv4.conf.default.rp_filter          1
 sysctl_set net.ipv4.conf.all.rp_filter              1
 sysctl_set net.ipv4.conf.all.accept_redirects       0


### PR DESCRIPTION
Disables TCP timestamps (`net.ipv4.tcp_timestamps=0`) via the sysctl hardening section of the install script.

TCP timestamps (RFC 1323) expose system uptime and can aid OS fingerprinting and timing-based attacks. Disabling them is a low-risk, no-performance-impact hardening measure for server VMs where high-latency link optimisations are not needed.

- Docker-compatible: does not affect container networking
- Idempotent: uses the existing `sysctl_set` helper
- Reference: https://obscurix.github.io/security/kernel-hardening.html

Closes #85