### PR TITLE
docs: add AI instructions for issue and PR assignment rules

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -27,7 +27,14 @@ Before starting any work:
   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
   ```
 
+## Issue Assignment
+
+- Before picking up an issue, assign it to yourself: `gh issue edit <number> --add-assignee @me`
+- Do not pick up issues already assigned to someone else.
+- Do not work on issues labelled `on-hold`.
+
 ## Pull Requests
 
 - PRs must be reviewed by at least one other maintainer before merging.
 - All changes must be tested and verified before merging.
+- Always add yourself as assignee when creating or updating a PR: `gh pr edit <number> --add-assignee @me`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,1 @@
-# AI Instructions - credfeto-setup-arch-vm
-
-## Issue Assignment
-
-- When picking up an issue to work on, assign it to yourself (`gh issue edit <number> --add-assignee @me`) before starting work.
-- Do not pick up issues already assigned to someone else.
-- Only work on issues that are unassigned, or already assigned to you.
-
-## PR Assignment
-
-- When creating or updating a PR, always add yourself as an assignee (`gh pr edit <number> --add-assignee @me`).
-
-## General Rules
-
-- Always pull from origin/main before creating a new branch.
-- One PR per issue.
-- Do not work on issues labelled `on-hold`.
+Use the instructions in [AI Instructions](.ai-instructions) to do everything.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# AI Instructions - credfeto-setup-arch-vm
+
+## Issue Assignment
+
+- When picking up an issue to work on, assign it to yourself (`gh issue edit <number> --add-assignee @me`) before starting work.
+- Do not pick up issues already assigned to someone else.
+- Only work on issues that are unassigned, or already assigned to you.
+
+## PR Assignment
+
+- When creating or updating a PR, always add yourself as an assignee (`gh pr edit <number> --add-assignee @me`).
+
+## General Rules
+
+- Always pull from origin/main before creating a new branch.
+- One PR per issue.
+- Do not work on issues labelled `on-hold`.


### PR DESCRIPTION
Adds a CLAUDE.md with rules for the AI assistant working in this repo:

- Assign yourself to an issue before starting work
- Do not pick up issues assigned to someone else
- Always add yourself as assignee when creating or updating a PR
- Never work on issues/PRs labelled `on-hold`
- Always pull origin/main before creating a new branch