### PR TITLE
feat: Improve ASLR entropy via vm.mmap_rnd_bits and vm.mmap_rnd_compat_bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable auditd service for AppArmor audit event logging
 - Remove orphaned packages inline after package install step rather than via a systemd timer
 - Enforce signed kernel modules via module.sig_enforce=1 GRUB parameter to prevent loading of unsigned modules
+- Improve ASLR entropy via vm.mmap_rnd_bits=32 and vm.mmap_rnd_compat_bits=16
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/install
+++ b/install
@@ -799,6 +799,10 @@ sysctl_set kernel.kexec_load_disabled               1
 sysctl_set kernel.kptr_restrict                     2
 sysctl_set kernel.yama.ptrace_scope                 2
 sysctl_set kernel.randomize_va_space                2
+# Maximise ASLR entropy for 64-bit and 32-bit compat mmap allocations
+# Reference: https://obscurix.github.io/security/kernel-hardening.html
+sysctl_set vm.mmap_rnd_bits                         32
+sysctl_set vm.mmap_rnd_compat_bits                  16
 sysctl_set kernel.sysrq                             0
 sysctl_set net.ipv4.tcp_syncookies                  1
 sysctl_set net.ipv4.tcp_rfc1337                     1


### PR DESCRIPTION
## Summary

- Set `vm.mmap_rnd_bits=32` to maximise 64-bit mmap ASLR entropy on x86_64
- Set `vm.mmap_rnd_compat_bits=16` to maximise 32-bit compat mmap ASLR entropy
- Both settings are idempotent via the existing `sysctl_set` helper and fully Docker-compatible

## Rationale

`kernel.randomize_va_space=2` (already set) enables ASLR, but the default entropy bits used for mmap base address randomisation are often lower than the kernel maximum. Setting `vm.mmap_rnd_bits=32` uses the full entropy available on x86_64, making heap/stack spray and return-oriented programming attacks significantly harder. `vm.mmap_rnd_compat_bits=16` applies the same benefit to 32-bit compat processes.

Reference: https://obscurix.github.io/security/kernel-hardening.html

Closes #84

## Test plan

- [ ] Run `install` script on a clean Arch Linux VM — `vm.mmap_rnd_bits` and `vm.mmap_rnd_compat_bits` should show `ok` on first run
- [ ] Run `install` script a second time — both settings should show `skip` (idempotency)
- [ ] Verify `sysctl vm.mmap_rnd_bits` returns `32` and `sysctl vm.mmap_rnd_compat_bits` returns `16` after running
- [ ] Confirm Docker containers still start and networking works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)