### PR TITLE
docs(instructions): abort if git identity is wrong or GPG signing is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- AI instructions: mandatory git identity and GPG signing check before any commit — abort if identity is `andy@nanoclaw.ai` or GPG signing is disabled
 - SSH hardening with strong crypto, key-only auth, and no root login
 - Additional sysctl hardening: ASLR, sysrq disable, source route blocking, RA disable, ICMP broadcast, filesystem protections, core dump prevention
 - Core dump disabling via systemd DefaultLimitCORE=0


### PR DESCRIPTION
Adds a mandatory git identity check to the git-workflow instructions. Before any commit, the agent must verify the email is not `andy@nanoclaw.ai` and that GPG signing is enabled — and abort if either check fails.