### PR TITLE
fix: add bridge-nf-call-iptables sysctl and firewalld masquerade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Skip manual reflector.service start when reflector.timer is already active
 - Add idempotency check for reflector.conf configuration
 - Disable TCP timestamps (net.ipv4.tcp_timestamps=0) to prevent uptime leakage and OS fingerprinting
+- set net.bridge.bridge-nf-call-iptables=0 via sysctl; enable firewalld masquerade with --add-masquerade
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -228,6 +228,14 @@ firewalld_allow_private() {
 
 firewalld_allow_private tcp 22
 
+if ! firewall-cmd --permanent --query-masquerade > /dev/null 2>&1; then
+    firewall-cmd --permanent --add-masquerade || die "Could not add masquerade to firewalld"
+    FIREWALLD_CHANGED=1
+    ok "firewalld: masquerade enabled"
+else
+    skip "firewalld: masquerade already enabled"
+fi
+
 if [ "${FIREWALLD_CHANGED}" = "1" ]; then
     firewall-cmd --reload || die "Could not reload firewalld"
     ok "firewalld reloaded"
@@ -813,6 +821,7 @@ sysctl_set net.ipv6.conf.all.accept_source_route    0
 sysctl_set net.ipv6.conf.default.accept_source_route 0
 sysctl_set net.ipv6.conf.all.accept_ra              0
 sysctl_set net.ipv6.conf.default.accept_ra          0
+sysctl_set net.bridge.bridge-nf-call-iptables        0
 sysctl_set net.ipv4.icmp_echo_ignore_all            1
 sysctl_set net.ipv4.icmp_echo_ignore_broadcasts     1
 sysctl_set net.ipv4.icmp_ignore_bogus_error_responses 1


### PR DESCRIPTION
## Summary

• `sysctl`: set `net.bridge.bridge-nf-call-iptables = 0` — prevents bridge netfilter passing bridged traffic through iptables
• `firewall-cmd --permanent --add-masquerade` — enables NAT masquerade so container/VM traffic can be forwarded through the host; idempotent (checks `--query-masquerade` first)

## Test plan

- [ ] CI passes
- [ ] `firewall-cmd --query-masquerade` returns `yes` after running
- [ ] `sysctl net.bridge.bridge-nf-call-iptables` returns `0` after running

🤖 Generated with [Claude Code](https://claude.com/claude-code)