### PR TITLE
fix: rp_filter loose mode and persist ip_forward for Docker container networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add idempotency check for reflector.conf configuration
 - Disable TCP timestamps (net.ipv4.tcp_timestamps=0) to prevent uptime leakage and OS fingerprinting
 - set net.bridge.bridge-nf-call-iptables=0 via sysctl; enable firewalld masquerade with --add-masquerade
+- change rp_filter from strict (1) to loose (2) to allow Docker container routing; persist net.ipv4.ip_forward=1 so container traffic survives sysctl reloads
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -805,8 +805,13 @@ sysctl_set net.ipv4.tcp_rfc1337                     1
 # Disable TCP timestamps to prevent uptime/fingerprinting leakage (RFC 1323 optional feature)
 # Reference: https://obscurix.github.io/security/kernel-hardening.html
 sysctl_set net.ipv4.tcp_timestamps                  0
-sysctl_set net.ipv4.conf.default.rp_filter          1
-sysctl_set net.ipv4.conf.all.rp_filter              1
+# Loose reverse-path filtering (2) instead of strict (1): strict mode drops packets on
+# asymmetric routes (e.g. Docker container traffic via docker0) even when they are valid.
+sysctl_set net.ipv4.conf.default.rp_filter          2
+sysctl_set net.ipv4.conf.all.rp_filter              2
+# Persist IP forwarding so routed traffic (Docker containers, VMs) can reach external networks.
+# Docker enables this at runtime but does not persist it; a sysctl reload would revert it.
+sysctl_set net.ipv4.ip_forward                      1
 sysctl_set net.ipv4.conf.all.accept_redirects       0
 sysctl_set net.ipv4.conf.default.accept_redirects   0
 sysctl_set net.ipv4.conf.all.secure_redirects       0


### PR DESCRIPTION
## Summary

Two sysctl settings were preventing Docker containers from reaching external networks:

• **`rp_filter` 1→2** (strict→loose): strict mode silently drops return packets for containers because Docker uses asymmetric routing — traffic leaves via `docker0` (NATed out `eth0`) but return packets are seen on an asymmetric path that fails the strict check. Loose mode still rejects spoofed source addresses (checks reachability via *any* interface) without breaking valid asymmetric routes.

• **`net.ipv4.ip_forward = 1`** (persistent): Docker sets this at runtime but doesn't persist it. Without an explicit `sysctl.d` entry, a sysctl reload (e.g. after an update or service restart) resets it to 0, silently breaking all container networking until Docker is restarted.

## Test plan

- [ ] CI passes
- [ ] Docker containers can reach external IPs after running
- [ ] `sysctl net.ipv4.conf.all.rp_filter` returns `2`
- [ ] `sysctl net.ipv4.ip_forward` returns `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)