### PR TITLE
fix: correct net.bridge.bridge-nf-call-iptables to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Disable TCP timestamps (net.ipv4.tcp_timestamps=0) to prevent uptime leakage and OS fingerprinting
 - set net.bridge.bridge-nf-call-iptables=0 via sysctl; enable firewalld masquerade with --add-masquerade
 - change rp_filter from strict (1) to loose (2) to allow Docker container routing; persist net.ipv4.ip_forward=1 so container traffic survives sysctl reloads
+- net.bridge.bridge-nf-call-iptables corrected to 1 (was incorrectly set to 0 in #111) — value 1 enables iptables filtering on bridged traffic, required for Docker networking rules to apply to container traffic
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -830,7 +830,7 @@ sysctl_set net.ipv6.conf.all.accept_source_route    0
 sysctl_set net.ipv6.conf.default.accept_source_route 0
 sysctl_set net.ipv6.conf.all.accept_ra              0
 sysctl_set net.ipv6.conf.default.accept_ra          0
-sysctl_set net.bridge.bridge-nf-call-iptables        0
+sysctl_set net.bridge.bridge-nf-call-iptables        1
 sysctl_set net.ipv4.icmp_echo_ignore_all            1
 sysctl_set net.ipv4.icmp_echo_ignore_broadcasts     1
 sysctl_set net.ipv4.icmp_ignore_bogus_error_responses 1


### PR DESCRIPTION
# Description

PR #111 incorrectly set `net.bridge.bridge-nf-call-iptables` to `0`. The correct value is `1`.

Value `1` enables iptables/netfilter rules to be applied to bridged traffic, which is required for Docker to enforce its iptables rules on container-to-host and container-to-external traffic. Setting it to `0` bypasses those rules entirely, breaking Docker networking.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.