### PR TITLE
fix: set Docker firewall-backend to nftables in daemon.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - set net.bridge.bridge-nf-call-iptables=0 via sysctl; enable firewalld masquerade with --add-masquerade
 - change rp_filter from strict (1) to loose (2) to allow Docker container routing; persist net.ipv4.ip_forward=1 so container traffic survives sysctl reloads
 - net.bridge.bridge-nf-call-iptables corrected to 1 (was incorrectly set to 0 in #111) — value 1 enables iptables filtering on bridged traffic, required for Docker networking rules to apply to container traffic
+- Docker daemon.json: set firewall-backend to nftables so Docker uses nftables for its NAT/filtering rules, consistent with the system firewall (firewalld running in nftables mode)
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -147,6 +147,7 @@ DOCKER_DAEMON_EXPECTED=$(cat << 'EOF'
   "icc": false,
   "no-new-privileges": true,
   "userland-proxy": false,
+  "firewall-backend": "nftables",
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m",


### PR DESCRIPTION
# Description

Adds `"firewall-backend": "nftables"` to `/etc/docker/daemon.json`.

Arch Linux runs firewalld in nftables mode. Setting Docker's firewall backend to match ensures Docker writes its NAT/masquerade/filtering rules into nftables directly (via iptables-nft), keeping both systems on the same netfilter stack and avoiding conflicts between the legacy iptables backend and nftables.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.