### PR TITLE
fix: pass -H flag to sudo when running ansible-pull as autoupdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - net.bridge.bridge-nf-call-iptables corrected to 1 (was incorrectly set to 0 in #111) — value 1 enables iptables filtering on bridged traffic, required for Docker networking rules to apply to container traffic
 - Docker daemon.json: set firewall-backend to nftables so Docker uses nftables for its NAT/filtering rules, consistent with the system firewall (firewalld running in nftables mode)
 - Clarify TCP timestamps comment: document PAWS-bypass mitigation and relationship with net.ipv4.tcp_rfc1337=1
+- Pass -H flag to sudo when running ansible-pull as autoupdate user so HOME is set correctly
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/install
+++ b/install
@@ -133,7 +133,7 @@ ok "ansible-pull.timer enabled"
 
 # ── Run ansible-pull once immediately ─────────────────────────────────────────
 echo "Running ansible-pull to apply full configuration..."
-sudo -u autoupdate /usr/bin/ansible-pull \
+sudo -H -u autoupdate /usr/bin/ansible-pull \
     -U https://github.com/credfeto/credfeto-setup-arch-vm.git \
     -C main site.yml \
     || die "ansible-pull failed"


### PR DESCRIPTION
## Summary

Fixes #126

When the `install` script runs `sudo -u autoupdate ansible-pull` at the end of bootstrap, it doesn't reset `$HOME`. The calling process is root, so `$HOME=/root`. `ansible-pull` then attempts to create its working directory at `/root/.ansible/pull/<hostname>/`, which the `autoupdate` user cannot write to — producing the `[Errno 12] Permission denied: b'/root'` error.

Adding `-H` to the `sudo` invocation resets `HOME` to the target user's home directory (`/home/autoupdate`) before exec-ing `ansible-pull`, so the working directory is created under a path the user controls.

## Changes

• `install`: `sudo -u autoupdate` → `sudo -H -u autoupdate` on the initial ansible-pull run

## Test plan

- [ ] Fresh install: verify `ansible-pull` completes without the permission error on first run
- [ ] Re-run install: verify idempotency — no errors on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)