### PR TITLE
fix: run sysctl role before docker role on first provisioning

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -59,6 +59,16 @@ Before starting any work:
 - Do not pick up issues already assigned to someone else.
 - Do not work on issues labelled `on-hold`.
 
+## One Active Branch at a Time
+
+**Never start work on a new issue or branch while a PR is open.** This is an absolute rule:
+
+- Only one branch and one PR may be open at any time.
+- Do not create a new branch until the current PR is **merged** (not just opened, not just approved — fully merged into `main`).
+- Do not do preparatory work, stage commits, or push anything to a second branch while waiting for a PR to merge.
+- If a new issue is raised while a PR is open, note it and wait.
+- This applies even if the new issue seems quick or unrelated — stacked branches create conflicts and confusion.
+
 ## Multi-Agent Implementation and Review Pattern
 
 All implementation work uses a two-agent loop:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Docker daemon.json: set firewall-backend to nftables so Docker uses nftables for its NAT/filtering rules, consistent with the system firewall (firewalld running in nftables mode)
 - Clarify TCP timestamps comment: document PAWS-bypass mitigation and relationship with net.ipv4.tcp_rfc1337=1
 - Pass -H flag to sudo when running ansible-pull as autoupdate user so HOME is set correctly
+- Run sysctl role before docker role so ip_forward and bridge sysctls are set before Docker starts
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Clarify TCP timestamps comment: document PAWS-bypass mitigation and relationship with net.ipv4.tcp_rfc1337=1
 - Pass -H flag to sudo when running ansible-pull as autoupdate user so HOME is set correctly
 - Run sysctl role before docker role so ip_forward and bridge sysctls are set before Docker starts
+- Load br_netfilter module before applying net.bridge.bridge-nf-call-iptables sysctl so the setting succeeds on first provision
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -224,6 +224,19 @@
     sysctl_file: /etc/sysctl.d/10-net.ipv6.conf.default.accept_ra.conf
     reload: true
 
+- name: Load br_netfilter module (required before bridge sysctl can be set)
+  community.general.modprobe:
+    name: br_netfilter
+    state: present
+
+- name: Persist br_netfilter module loading across reboots
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/br_netfilter.conf
+    content: "br_netfilter\n"
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Set net.bridge.bridge-nf-call-iptables
   ansible.posix.sysctl:
     name: net.bridge.bridge-nf-call-iptables

--- a/site.yml
+++ b/site.yml
@@ -7,9 +7,9 @@
   roles:
     - packages
     - users
-    - docker
     - sysctl
     - proc
+    - docker
     - grub
     - ssh
     - firewall


### PR DESCRIPTION
## Summary

Fixes #130

On a fresh machine, Docker fails to start because the required kernel parameters haven't been set yet:
- `net.ipv4.ip_forward=1` — needed for container routing
- `net.bridge.bridge-nf-call-iptables=1` — needed for Docker iptables rules on bridged traffic
- `net.ipv4.conf.all.rp_filter=2` — needed to avoid dropping container return packets

`site.yml` was running the `docker` role before `sysctl`, so Docker started before these were applied. Moving `sysctl` (and `proc`) ahead of `docker` fixes the ordering.

## Changes

• `site.yml`: move `sysctl` and `proc` roles before `docker`

## Test plan

- [ ] Run ansible-pull on a fresh Arch VM and verify Docker starts without the ip_forward error
- [ ] Verify sysctl settings are applied before Docker daemon starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)