### PR TITLE
fix: replace unsupported ignore_errors with ignoreerrors in sysctl tasks (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
+### Fixed
+- Replace unsupported `ignore_errors` task keyword (incorrectly indented inside `ansible.posix.sysctl` module params) with the module's own `ignoreerrors: true` parameter for `kernel.kexec_load_disabled` and `kernel.deny_new_usb` tasks
+
 ### Added
 - Git workflow instructions: never-squash-commits rule to preserve the full commit history however messy the path
 - AI instructions: mandatory git identity and GPG signing check before any commit — abort if identity is `andy@nanoclaw.ai` or GPG signing is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
-### Fixed
-- Replace unsupported `ignore_errors` task keyword (incorrectly indented inside `ansible.posix.sysctl` module params) with the module's own `ignoreerrors: true` parameter for `kernel.kexec_load_disabled` and `kernel.deny_new_usb` tasks
-
 ### Added
 - Git workflow instructions: never-squash-commits rule to preserve the full commit history however messy the path
 - AI instructions: mandatory git identity and GPG signing check before any commit — abort if identity is `andy@nanoclaw.ai` or GPG signing is disabled
@@ -73,6 +70,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Pass -H flag to sudo when running ansible-pull as autoupdate user so HOME is set correctly
 - Run sysctl role before docker role so ip_forward and bridge sysctls are set before Docker starts
 - Load br_netfilter module before applying net.bridge.bridge-nf-call-iptables sysctl so the setting succeeds on first provision
+- Replace unsupported ignore_errors task keyword with module's own ignoreerrors: true parameter for kernel.kexec_load_disabled and kernel.deny_new_usb sysctl tasks
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -26,7 +26,7 @@
     value: "1"
     sysctl_file: /etc/sysctl.d/10-kernel.kexec_load_disabled.conf
     reload: true
-    ignore_errors: true  # noqa: ignore-errors - key may not exist in hardened kernel
+    ignoreerrors: true
 
 - name: Set kernel.kptr_restrict
   ansible.posix.sysctl:
@@ -334,7 +334,7 @@
     value: "1"
     sysctl_file: /etc/sysctl.d/10-kernel.deny_new_usb.conf
     reload: true
-    ignore_errors: true  # noqa: ignore-errors - key may not exist in all kernels
+    ignoreerrors: true
 
 - name: Set net.ipv4.tcp_sack
   ansible.posix.sysctl:


### PR DESCRIPTION
## Summary
- Fixes `ansible.posix.sysctl` failing due to `ignore_errors: true` being incorrectly indented inside the module parameters block (treated as an unsupported module parameter)
- Replaces `ignore_errors: true` with the module's supported `ignoreerrors: true` parameter for two tasks: `kernel.kexec_load_disabled` and `kernel.deny_new_usb`
- These tasks legitimately need to tolerate missing kernel keys (e.g. on hardened kernels), so `ignoreerrors: true` is the semantically correct fix

Closes #134

## Test plan
- [ ] Verify Ansible lint passes with no `unsupported parameter` warnings on these tasks
- [ ] Run the playbook against a test host and confirm `kernel.kexec_load_disabled` and `kernel.deny_new_usb` tasks no longer fail
- [ ] Confirm behaviour is unchanged on kernels that do support these keys