### PR TITLE
feat: configure sshd AuthorizedKeysCommand to look up SSH public keys from keys.markridgwell.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Blacklist kernel modules esp4, esp6, and rxrpc affected by Dirty Frag (CVE-2026-43284, CVE-2026-43500) to prevent local privilege escalation
 - Schedule reboot 60 s after Ansible run when kernel image or GRUB config changed since last boot
 - Ensure user 'markr' exists with sudo NOPASSWD, SSH-only login, and authorized SSH keys from GitHub
+- Configure sshd AuthorizedKeysCommand to look up SSH public keys from keys.markridgwell.com
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -86,6 +86,7 @@
       - ansible
       - apparmor
       - audit
+      - curl
       - docker
       - docker-buildx
       - docker-compose

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -127,6 +127,25 @@
     mode: "0600"
   notify: Reload sshd
 
+# Key lookup
+- name: Configure sshd AuthorizedKeysCommand
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/10-authorizedkeyscommand.conf
+    content: "AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/%H/%u\n"
+    owner: root
+    group: root
+    mode: "0600"
+  notify: Reload sshd
+
+- name: Configure sshd AuthorizedKeysCommandUser
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/10-authorizedkeyscommanduser.conf
+    content: "AuthorizedKeysCommandUser nobody\n"
+    owner: root
+    group: root
+    mode: "0600"
+  notify: Reload sshd
+
 # Session
 - name: Configure sshd X11Forwarding
   ansible.builtin.copy:


### PR DESCRIPTION
## Summary

- Configures `AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/%H/%u` so sshd looks up public keys from the central key server at login time
- Configures `AuthorizedKeysCommandUser nobody` to run the lookup command under an unprivileged user
- Adds `curl` to the managed packages list to ensure it is always present

Closes #147

## Test plan

- [ ] Run playbook against `arch-vm-test.lan` and confirm `failed=0`
- [ ] Verify `/etc/ssh/sshd_config.d/10-authorizedkeyscommand.conf` and `10-authorizedkeyscommanduser.conf` are created with correct content
- [ ] Confirm `sshd` reloads cleanly after playbook run
- [ ] Re-run playbook to confirm idempotency (no changes on second run)