### PR TITLE
feat: switch default container runtime to Podman; install companions based on active runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Schedule reboot 60 s after Ansible run when kernel image or GRUB config changed since last boot
 - Ensure user 'markr' exists with sudo NOPASSWD, SSH-only login, and authorized SSH keys from GitHub
 - Configure sshd AuthorizedKeysCommand to look up SSH public keys from keys.markridgwell.com
+- Podman as the default container runtime for new VMs (controlled by container_runtime variable)
+- Podman registries mirror configuration via /etc/containers/registries.conf
+- podman-cleanup.timer to prune unused Podman images weekly
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run
@@ -110,6 +113,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Simplify install script to bootstrap only: install ansible+git, install Galaxy collections, run ansible-pull once — all further configuration (user, sudoers, service, timer) is now managed exclusively by the playbook
 - security-review: rewrite workflow to analyse Ansible role YAML files (`roles/**/tasks/main.yml`, `site.yml`) instead of the install shell script; security findings are now reported as GitHub issues labelled `AI-Work` rather than opening pull requests with direct code changes; added `AI-Work` label definition to `.github/labels.yml`
 - Randomise systemd timer offsets to prevent simultaneous runs across VMs
+- Docker packages (docker-buildx, docker-compose) only installed when container_runtime is set to docker
+- Docker firewalld zone only created when container_runtime is set to docker
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/ai/local/docker-compatibility.instructions.md
+++ b/ai/local/docker-compatibility.instructions.md
@@ -1,29 +1,43 @@
 ---
-description: 'Rules ensuring all configuration is compatible with Docker.'
+description: 'Rules ensuring all configuration is compatible with the active container runtime (Docker or Podman).'
 applyTo: '**'
 ---
 
+# Container Runtime Compatibility
+
 [Back to Local Instructions Index](index.md)
 
-# Docker Compatibility
+The active container runtime is controlled by the `container_runtime` variable (default: `podman`). All settings must be compatible with whichever runtime is active.
 
-**All settings must be compatible with Docker.** Never add a kernel parameter, sysctl value, or any other configuration that will break Docker or Docker-based workloads.
+Never add a kernel parameter, sysctl value, or any other configuration that will break the active container runtime or container-based workloads.
 
 When evaluating any new setting, verify it does not interfere with:
-- Docker bridge networking (`docker0`, `br-*`)
+
+- Container bridge networking (e.g. `docker0`, `br-*`, or `cni-*` for Podman)
 - Container network namespaces and veth pairs
 - Rootless or privileged container operation
 
 ## Known Incompatible Settings
 
-The following must **never** be added:
+The following must **never** be added regardless of runtime:
 
 | Setting | Reason |
-|---|---|
-| `kernel.unprivileged_userns_clone=0` | Breaks Docker networking and rootless containers |
+| --- | --- |
+| `kernel.unprivileged_userns_clone=0` | Breaks networking and rootless containers for both Docker and Podman |
 
-## Firewalld and Docker
+## Firewalld and Docker (`container_runtime: docker`)
 
 firewalld's `filter_FORWARD` chain (priority `filter+10`) runs after Docker's own nft rules (priority `filter`). New outbound connections from containers hit the public zone's empty `filter_FWD_public_allow` chain and are rejected.
 
-To allow Docker containers to reach LAN hosts, the `172.16.0.0/12` subnet (covers all default Docker bridge ranges) must be assigned as a source to the `docker` firewalld zone, which has `target: ACCEPT`. This is managed by the `firewall` role and must not be removed.
+To allow Docker containers to reach LAN hosts, the `172.16.0.0/12` subnet (covers all default Docker bridge ranges) must be assigned as a source to the `docker` firewalld zone, which has `target: ACCEPT`. This is managed by the `firewall` role under the `container_runtime == 'docker'` guard and must not be removed.
+
+## Firewalld and Podman (`container_runtime: podman`)
+
+Podman (rootful) uses CNI or netavark networking. No dedicated firewalld zone is required; the `docker` zone tasks are skipped entirely when `container_runtime == 'podman'`.
+
+## Runtime Selection
+
+| Variable value | Runtime installed | Companion packages | Firewall zone | Cleanup timer |
+| --- | --- | --- | --- | --- |
+| `podman` (default) | `podman`, `buildah` | `podman-compose` | None | `podman-cleanup.timer` |
+| `docker` | `docker` | `docker-buildx`, `docker-compose` | `docker` zone (ACCEPT, 172.16.0.0/12) | `docker-cleanup.timer` |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,4 @@
+---
+# container_runtime controls which container engine is installed.
+# Use 'podman' for new VMs (default). Set to 'docker' for existing Docker hosts.
+container_runtime: podman

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -6,6 +6,7 @@
     owner: root
     group: root
     mode: "0755"
+  when: container_runtime == 'docker'
 
 - name: Configure Docker daemon
   ansible.builtin.copy:
@@ -15,12 +16,14 @@
     group: root
     mode: "0644"
   notify: Restart docker
+  when: container_runtime == 'docker'
 
 - name: Remove legacy Docker systemd security drop-in
   ansible.builtin.file:
     path: /etc/systemd/system/docker.service.d/security.conf
     state: absent
   notify: Reload systemd
+  when: container_runtime == 'docker'
 
 - name: Enable and start docker.socket
   ansible.builtin.systemd:
@@ -28,9 +31,11 @@
     enabled: true
     state: started
     daemon_reload: true
+  when: container_runtime == 'docker'
 
 - name: Enable and start docker service
   ansible.builtin.systemd:
     name: docker
     enabled: true
     state: started
+  when: container_runtime == 'docker'

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -75,7 +75,7 @@
     state: enabled
   notify: Reload firewalld
 
-# On a fresh VM the docker zone may not exist yet — create it explicitly.
+# Docker zone — only needed when container_runtime is docker.
 # Docker uses the nftables backend and does not register a firewalld zone.
 - name: Check if docker firewalld zone exists
   ansible.builtin.command:
@@ -83,23 +83,24 @@
   register: firewall_docker_zone_check
   changed_when: false
   failed_when: false
+  when: container_runtime == 'docker'
 
 - name: Create docker firewalld zone
   ansible.builtin.command:
     cmd: firewall-cmd --permanent --new-zone=docker
-  when: firewall_docker_zone_check.rc != 0
+  when: container_runtime == 'docker' and firewall_docker_zone_check.rc != 0
   changed_when: true
 
 - name: Set docker zone target to ACCEPT
   ansible.builtin.command:
     cmd: firewall-cmd --permanent --zone=docker --set-target=ACCEPT
-  when: firewall_docker_zone_check.rc != 0
+  when: container_runtime == 'docker' and firewall_docker_zone_check.rc != 0
   changed_when: true
 
 - name: Reload firewalld to activate docker zone
   ansible.builtin.command:
     cmd: firewall-cmd --reload
-  when: firewall_docker_zone_check.rc != 0
+  when: container_runtime == 'docker' and firewall_docker_zone_check.rc != 0
   changed_when: true
 
 - name: Assign Docker bridge subnet to docker zone
@@ -109,3 +110,4 @@
     permanent: true
     state: enabled
   notify: Reload firewalld
+  when: container_runtime == 'docker'

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -87,9 +87,6 @@
       - apparmor
       - audit
       - curl
-      - docker
-      - docker-buildx
-      - docker-compose
       - fail2ban
       - firewalld
       - git
@@ -100,6 +97,26 @@
       - reflector
     state: present
     extra_args: "--noconfirm --needed"
+
+- name: Install Docker and companions
+  community.general.pacman:
+    name:
+      - docker
+      - docker-buildx
+      - docker-compose
+    state: present
+    extra_args: "--noconfirm --needed"
+  when: container_runtime == 'docker'
+
+- name: Install Podman and companions
+  community.general.pacman:
+    name:
+      - podman
+      - podman-compose
+      - buildah
+    state: present
+    extra_args: "--noconfirm --needed"
+  when: container_runtime == 'podman'
 
 - name: Remove AUR helpers (prohibited due to supply chain attack risk)
   community.general.pacman:

--- a/roles/podman/files/registries.conf
+++ b/roles/podman/files/registries.conf
@@ -1,0 +1,8 @@
+unqualified-search-registries = ["docker.io"]
+
+[[registry]]
+prefix = "docker.io"
+location = "docker.io"
+
+[[registry.mirror]]
+location = "docker-cache.markridgwell.com"

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure /etc/containers directory exists
+  ansible.builtin.file:
+    path: /etc/containers
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: container_runtime == 'podman'
+
+- name: Configure Podman registries
+  ansible.builtin.copy:
+    src: registries.conf
+    dest: /etc/containers/registries.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: container_runtime == 'podman'

--- a/roles/services/files/podman-cleanup.service
+++ b/roles/services/files/podman-cleanup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Remove unused podman images
+
+[Service]
+Type=oneshot
+ExecStart=podman image prune --all --force
+ProtectSystem=full
+ProtectHome=true
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictSUIDSGID=true

--- a/roles/services/files/podman-cleanup.timer
+++ b/roles/services/files/podman-cleanup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Remove unused podman images weekly
+
+[Timer]
+OnCalendar=weekly
+RandomizedDelaySec=1h
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/services/tasks/main.yml
+++ b/roles/services/tasks/main.yml
@@ -51,7 +51,7 @@
     state: started
     daemon_reload: true
 
-# docker-cleanup service + timer
+# docker-cleanup service + timer (Docker runtime only)
 - name: Install docker-cleanup.service unit
   ansible.builtin.copy:
     src: docker-cleanup.service
@@ -60,6 +60,7 @@
     group: root
     mode: "0644"
   notify: Reload systemd
+  when: container_runtime == 'docker'
 
 - name: Install docker-cleanup.timer unit
   ansible.builtin.copy:
@@ -69,6 +70,7 @@
     group: root
     mode: "0644"
   notify: Reload systemd
+  when: container_runtime == 'docker'
 
 - name: Enable and start docker-cleanup timer
   ansible.builtin.systemd:
@@ -76,6 +78,36 @@
     enabled: true
     state: started
     daemon_reload: true
+  when: container_runtime == 'docker'
+
+# podman-cleanup service + timer (Podman runtime only)
+- name: Install podman-cleanup.service unit
+  ansible.builtin.copy:
+    src: podman-cleanup.service
+    dest: /etc/systemd/system/podman-cleanup.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+  when: container_runtime == 'podman'
+
+- name: Install podman-cleanup.timer unit
+  ansible.builtin.copy:
+    src: podman-cleanup.timer
+    dest: /etc/systemd/system/podman-cleanup.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+  when: container_runtime == 'podman'
+
+- name: Enable and start podman-cleanup timer
+  ansible.builtin.systemd:
+    name: podman-cleanup.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: container_runtime == 'podman'
 
 # pkgstats timer (ships with the pkgstats package)
 - name: Enable and start pkgstats timer

--- a/site.yml
+++ b/site.yml
@@ -11,6 +11,7 @@
     - kernel_modules
     - proc
     - docker
+    - podman
     - grub
     - ssh
     - firewall


### PR DESCRIPTION
## Summary

- New VMs now default to **Podman** as the container runtime (controlled by the `container_runtime` variable in `group_vars/all.yml`).
- Existing Docker VMs retain full Docker support by setting `container_runtime: docker` in their inventory.
- The correct companion packages are installed based on which runtime is active.

## Changes

| Area | Docker (`container_runtime: docker`) | Podman (`container_runtime: podman`, default) |
| --- | --- | --- |
| Packages | `docker`, `docker-buildx`, `docker-compose` | `podman`, `podman-compose`, `buildah` |
| Config | `/etc/docker/daemon.json` (registry mirror, hardening) | `/etc/containers/registries.conf` (registry mirror) |
| Firewall | docker zone created, `172.16.0.0/12` assigned | No docker zone |
| Cleanup timer | `docker-cleanup.timer` | `podman-cleanup.timer` |

## Files changed

- `group_vars/all.yml` — new; sets `container_runtime: podman`
- `roles/packages/tasks/main.yml` — conditional package installation
- `roles/docker/tasks/main.yml` — all tasks guarded with `when: container_runtime == 'docker'`
- `roles/podman/` — new role; configures `/etc/containers/registries.conf`
- `roles/services/tasks/main.yml` — conditional cleanup timer
- `roles/services/files/podman-cleanup.{service,timer}` — new units
- `roles/firewall/tasks/main.yml` — docker zone tasks guarded with `when: container_runtime == 'docker'`
- `site.yml` — podman role added
- `ai/local/docker-compatibility.instructions.md` — updated to reflect dual-runtime architecture

Closes #154