### PR TITLE
feat: enable kernel.unprivileged_userns_clone=1 when Podman is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Podman as the default container runtime for new VMs (controlled by container_runtime variable)
 - Podman registries mirror configuration via /etc/containers/registries.conf
 - podman-cleanup.timer to prune unused Podman images weekly
+- Enable kernel.unprivileged_userns_clone=1 when Podman is installed for rootless container support
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -16,3 +16,11 @@
     group: root
     mode: "0644"
   when: container_runtime == 'podman'
+
+- name: Enable kernel.unprivileged_userns_clone for Podman rootless containers
+  ansible.posix.sysctl:
+    name: kernel.unprivileged_userns_clone
+    value: "1"
+    sysctl_file: /etc/sysctl.d/10-kernel.unprivileged_userns_clone.conf
+    reload: true
+  when: container_runtime == 'podman'


### PR DESCRIPTION
## Summary

- Adds a sysctl task in the podman role to set `kernel.unprivileged_userns_clone=1` guarded by `when: container_runtime == 'podman'`
- This is required for rootless Podman container support (user namespaces)

Closes #156

## Test plan

- [ ] Run the playbook with `container_runtime: podman` and verify `sysctl kernel.unprivileged_userns_clone` reports `1`
- [ ] Verify `/etc/sysctl.d/10-kernel.unprivileged_userns_clone.conf` is created with `kernel.unprivileged_userns_clone = 1`
- [ ] Re-run the playbook and confirm the task is idempotent (no change reported)
- [ ] Confirm no change is applied when `container_runtime: docker`