### PR TITLE
feat: configure Podman registry mirror to enforce HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Randomise systemd timer offsets to prevent simultaneous runs across VMs
 - Docker packages (docker-buildx, docker-compose) only installed when container_runtime is set to docker
 - Docker firewalld zone only created when container_runtime is set to docker
+- Explicitly set insecure = false on the Podman registry mirror to enforce HTTPS, matching the docker registry-mirrors configuration
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/roles/podman/files/registries.conf
+++ b/roles/podman/files/registries.conf
@@ -6,3 +6,4 @@ location = "docker.io"
 
 [[registry.mirror]]
 location = "docker-cache.markridgwell.com"
+insecure = false


### PR DESCRIPTION
## Summary

- Set `insecure = false` explicitly on the `docker.io` registry mirror entry in `/etc/containers/registries.conf` so Podman enforces TLS when pulling through `docker-cache.markridgwell.com`.
- This matches the Docker `daemon.json` configuration which uses `https://docker-cache.markridgwell.com` as the registry mirror, making the intent explicit rather than relying on the TOML default.

Closes #170

## Test plan

- [ ] Verify `podman pull` uses the mirror over HTTPS (check `/etc/containers/registries.conf` is deployed correctly by Ansible).
- [ ] Confirm no regression in Docker runtime path (no changes to Docker role or `daemon.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)