### PR TITLE
docs: fix stale PR-description automation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Run mkinitcpio -P after GRUB config changes to ensure initramfs stays in sync
 - Static /etc/resolv.conf on dns-?? hosts interleaves IPv6/IPv4 nameservers (offset so adjacent lines are never the same physical host) instead of listing all IPv6 first, so glibc's 3-line limit still gives 3 different hosts instead of only IPv6 ones
 - Exclude temporary and deprecated-flagged addresses from IPv4/IPv6 detection on the primary interface, so a rotating privacy-extension or expiring address never gets pinned into a static Address= line in eth0.network
+- AI instructions: pull-request-template.instructions.md no longer describes the deleted maintain-pr-description.yml automation as live; documents the actual hand-written PR description process instead
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/ai/local/index.md
+++ b/ai/local/index.md
@@ -23,5 +23,5 @@ This is an index of local instructions that apply to just this project.
 | [output-formatting.instructions.md](output-formatting.instructions.md) | ok / skip / die helper functions and coloured indicators for the install script |
 | [changelog.instructions.md](changelog.instructions.md) | Repo-specific changelog rules: install-script audience, when to add/skip entries, valid types including Deployment Changes |
 | [github-actions.instructions.md](github-actions.instructions.md) | Super-linter checks required, shell script pitfalls (SC2129, pipefail), GitHub Models API endpoint |
-| [pull-request-template.instructions.md](pull-request-template.instructions.md) | PR body structure; description is hand-written (no live auto-generation - the workflow was removed) |
+| [pull-request-template.instructions.md](pull-request-template.instructions.md) | PR body structure; description is hand-written |
 | [testing.instructions.md](testing.instructions.md) | Test VM at arch-vm-test.lan (user: test, sudo), when and how to validate Ansible role and install script changes |

--- a/ai/local/index.md
+++ b/ai/local/index.md
@@ -23,5 +23,5 @@ This is an index of local instructions that apply to just this project.
 | [output-formatting.instructions.md](output-formatting.instructions.md) | ok / skip / die helper functions and coloured indicators for the install script |
 | [changelog.instructions.md](changelog.instructions.md) | Repo-specific changelog rules: install-script audience, when to add/skip entries, valid types including Deployment Changes |
 | [github-actions.instructions.md](github-actions.instructions.md) | Super-linter checks required, shell script pitfalls (SC2129, pipefail), GitHub Models API endpoint |
-| [pull-request-template.instructions.md](pull-request-template.instructions.md) | PR body structure, auto-generated description via composite action, maintain-pr-description workflow rules |
+| [pull-request-template.instructions.md](pull-request-template.instructions.md) | PR body structure; description is hand-written (no live auto-generation - the workflow was removed) |
 | [testing.instructions.md](testing.instructions.md) | Test VM at arch-vm-test.lan (user: test, sudo), when and how to validate Ansible role and install script changes |

--- a/ai/local/pull-request-template.instructions.md
+++ b/ai/local/pull-request-template.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: 'Rules for pull request descriptions — template usage and automated description generation.'
+description: 'Rules for pull request descriptions — template usage and description writing.'
 applyTo: '**'
 ---
 
@@ -7,111 +7,38 @@ applyTo: '**'
 
 [Back to Local Instructions Index](index.md)
 
-**Every PR opened by an automated workflow must use `.github/PULL_REQUEST_TEMPLATE.md`** as its body structure, with the Description section filled in by Copilot.
+**Every PR must use `.github/PULL_REQUEST_TEMPLATE.md`** as its body structure.
 
-## How to generate the description
+## Current state: no automated description generation
 
-Before creating a PR, call the shared `generate-pr-description` composite action with the
-base and head SHAs. It diffs the two commits via the GitHub API and uses GitHub Copilot
-(GitHub Models) to write a concise description:
+There is no live automation that generates or maintains PR descriptions in this repo.
+`.github/workflows/maintain-pr-description.yml` was deleted from `main` on 2026-06-17
+(commit `bead402`, "Removed: Obsolete workflow") and nothing currently calls it. The
+`generate-pr-description` composite action (`.github/actions/generate-pr-description/`)
+still exists in the repo but is orphaned — no workflow references it, so it never runs.
 
-```yaml
-- name: "Generate PR description"
-  id: describe
-  uses: ./.github/actions/generate-pr-description
-  with:
-    base_sha: ${{ steps.push.outputs.base_sha }}
-    head_sha: ${{ steps.push.outputs.head_sha }}
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-```
+Do not assume a `<!-- maintained-by-copilot -->` marker in a PR body means anything is
+actively managing it — nothing is. Do not add that marker, or the
+`<!-- description-auto-generated-by-copilot -->` marker, to a body you write by hand;
+they would falsely imply automated maintenance that doesn't exist.
 
 ## How to compose the PR body
 
-Read the template, fill the `# Description` section with the generated text, and pass the
-complete body to `gh pr create --body`:
+Read `.github/PULL_REQUEST_TEMPLATE.md` and fill in every section yourself:
 
-```sh
-BODY=$(python3 - << 'PYEOF'
-import os, re
-template = open('.github/PULL_REQUEST_TEMPLATE.md').read().rstrip()
-desc = os.environ.get('DESCRIPTION', '').strip()
-marker = '<!-- description-auto-generated-by-copilot -->'
-maintained = '<!-- maintained-by-copilot -->'
-if desc:
-    body = re.sub(
-        r'(^#{1,3}\s+Description\s*\n)([\s\S]*?)(?=\n#{1,3}\s|$)',
-        lambda m: f"{m.group(1)}{desc}\n\n{marker}\n\n",
-        template, flags=re.MULTILINE)
-else:
-    body = template
-print(body + f'\n\n{maintained}')
-PYEOF
-)
-gh pr create --base main --head "${BRANCH}" --title "..." --body "${BODY}"
-```
+- `# Description`: hand-write a concise summary of what changed and why, from the diff
+  and commit messages.
+- `# How Has This Been Tested`: describe what was actually done (or explicitly note it
+  wasn't, e.g. a test VM being unavailable) — never tick a box that doesn't reflect reality.
+- `# Types of changes`, `## Deployment Configuration Changes`, `# Checklist`: fill in
+  based on the actual change.
 
-## Requirements for the calling job
+The body must always conform to the template's structure — never a freeform body, and
+never omit a section defined in the template.
 
-```yaml
-permissions:
-  pull-requests: write
-  contents: read
-  models: read
-```
+## If the automation is ever restored
 
-## Creating a PR
-
-When explicitly creating a pull request (e.g. via `gh pr create`), the body **must**:
-
-- Be built from `PULL_REQUEST_TEMPLATE.md` as its base structure — never supply a freeform body.
-- Include all sections defined in the template (`# Description`, `# How Has This Been Tested`,
-  `# Types of changes`, `## Deployment Configuration Changes`, `# Checklist`).
-- Have the `# Description` section filled with a generated description (via the composite action)
-  and the `<!-- description-auto-generated-by-copilot -->` marker.
-- End with the `<!-- maintained-by-copilot -->` marker so subsequent workflow runs can manage it.
-
-## Updating an Existing PR Description
-
-When updating a PR body (not creating it for the first time), apply the same logic used by
-`.github/workflows/maintain-pr-description.yml`.
-
-> **Important:** If the logic in `maintain-pr-description.yml` is ever changed, this instruction
-> file **must** be updated to reflect that new logic. These rules are derived from and must stay
-> in sync with that workflow — the workflow is the authoritative source of truth for update
-> behaviour.
-
-1. **Only manage bodies that contain `<!-- maintained-by-copilot -->`.**
-   If the marker is absent, do not touch the PR body.
-
-2. **Apply the template when the body is empty or still the bare template.**
-   Compare the current body (after stripping both markers) against the content of
-   `PULL_REQUEST_TEMPLATE.md`. If they match, or the body is blank, reset to:
-
-   ```text
-   <template content>
-
-   <!-- maintained-by-copilot -->
-   ```
-
-3. **Never replace a manually-written description.**
-   If the `# Description` section has real content and the
-   `<!-- description-auto-generated-by-copilot -->` marker is absent, leave the section
-   unchanged.
-
-4. **The updated body must always conform to `PULL_REQUEST_TEMPLATE.md`.**
-   Never write a PR body whose structure does not match the template — all sections
-   (`# Description`, `# How Has This Been Tested`, `# Types of changes`,
-   `## Deployment Configuration Changes`, `# Checklist`) must be present.
-
-5. **Re-generate the description via the composite action, do not hand-write it.**
-   Call `./.github/actions/generate-pr-description` with the PR's `base_sha` and
-   `head_sha`, then insert the output into the `# Description` section followed by
-   `<!-- description-auto-generated-by-copilot -->`.
-
-## Rules
-
-- Never hardcode a static PR body — always compose from the template with a generated description.
-- Generate the description **before** creating the PR so the body is complete at creation time.
-- The repo must be checked out before calling the action (local composite action at `./.github/actions/generate-pr-description`).
-- For `maintain-pr-description.yml`: call the action then update the PR body inline using the `description` output.
-- When updating a PR description, never produce a body that omits or restructures the sections defined in `PULL_REQUEST_TEMPLATE.md`.
+If `maintain-pr-description.yml` (or an equivalent) is reintroduced, update this file to
+describe its actual logic — the workflow, not this file, is the source of truth for how
+descriptions get generated/maintained. Until then, this file describes the manual process
+above.


### PR DESCRIPTION
# Description

`ai/local/pull-request-template.instructions.md` described a `maintain-pr-description.yml` workflow and its `generate-pr-description` composite-action call chain as if it were live and auto-populating PR bodies. That workflow was actually deleted from `main` on 2026-06-17 (commit `bead402`, "Removed: Obsolete workflow"), and the composite action it called is now orphaned - no workflow references it. This surfaced while working PR #178, whose body had gone unpopulated because there's no automation left to fill it in.

Rewrites the instructions to describe the actual current process (hand-write the `# Description` section per `PULL_REQUEST_TEMPLATE.md`, and don't add the `<!-- maintained-by-copilot -->` / `<!-- description-auto-generated-by-copilot -->` markers, since nothing consumes them anymore) and notes what to do if the automation is ever restored. Updates the local instructions index summary to match.

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

Docs-only change (an AI instructions file and its index entry) - no runtime behaviour to test. Verified with `markdownlint` (passing).

## Types of changes

- [x] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

None - this only changes AI instructions, not the install script or Ansible roles.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.

No CHANGELOG entry: per `ai/local/changelog.instructions.md`, changes to `ai/` files are explicitly excluded from requiring one.
