### PR TITLE
chore: pin GitHub Actions uses: references to commit SHA instead of tag (#180)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Checkout source"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Install Ansible and ansible-lint"
         run: pip install ansible ansible-lint

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           clean: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
+- Pin GitHub Actions checkout references to commit SHA (issue #180, implementation pending)
 ### Added
 - Git workflow instructions: never-squash-commits rule to preserve the full commit history however messy the path
 - AI instructions: mandatory git identity and GPG signing check before any commit — abort if identity is `andy@nanoclaw.ai` or GPG signing is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -132,6 +135,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Remove the redundant per-link DNS= from eth0.network; the fleet nameservers are now configured in exactly one place (the global systemd-resolved drop-in) instead of twice for every non-dns-?? host
 - Derive the fleet nameserver IPv4/IPv6 address lists from a single list of host suffixes plus fixed prefixes, instead of two independently hand-maintained lists, so they can no longer drift out of sync in length or content
 - Order systemd-resolved's global DNS= as IPv6 nameservers before IPv4, matching the static resolv.conf's ordering
+### Deprecated
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script
 - Remove curl-based security script in favour of ansible-pull timer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
-- Pin GitHub Actions checkout references to commit SHA (issue #180, implementation pending)
+- Pin actions/checkout references to commit SHA instead of mutable tag in ansible-lint and security-review workflows, hardening against tag repointing
 ### Added
 - Git workflow instructions: never-squash-commits rule to preserve the full commit history however messy the path
 - AI instructions: mandatory git identity and GPG signing check before any commit — abort if identity is `andy@nanoclaw.ai` or GPG signing is disabled
@@ -62,6 +62,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Pin IPv6AcceptRA=no on the primary interface so systemd-networkd doesn't override the sysctl role's RA-acceptance hardening for that link
 - Set Domains=~. in the systemd-resolved global config so unqualified lookups are never suffixed with a search domain, matching the static resolv.conf's search .
 - Fail the run with a clear error if network_nameservers_ipv4 and network_nameservers_ipv6 are ever configured with different lengths, instead of silently dropping the extra entries from dns-?? hosts' resolv.conf
+- Enable Dependabot github-actions ecosystem to keep SHA-pinned action versions up to date
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Bootstrap PR for issue #180 (pin `actions/checkout` `uses:` references to commit SHA instead of tag, and add the `github-actions` Dependabot ecosystem).

This PR currently contains only branch/PR bootstrap work:
- A fix to a pre-existing structural gap in `CHANGELOG.md` (missing `### Deprecated` section in `[Unreleased]`), applied via `dotnet changelog --lint --fix` - required before any commit touching the file could pass the changelog lint.
- A placeholder `CHANGELOG.md` entry under `### Security` tracking the pending work for #180.

The actual workflow-file changes (`.github/workflows/ansible-lint.yml`, `.github/workflows/security-review.yml`) and the new `.github/dependabot.yml` will be added in a follow-up commit per the approved implementation plan on the issue.

Closes #180

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing:
No production code changed yet. `git commit` ran the repo's pre-commit hook (yamllint, ansible-lint, actionlint, changelog lint, etc.) locally and it passed on both commits in this PR.

## Types of changes

- [x] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md
No deployment configuration changes required.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.