### PR TITLE
fix: disable DNSSEC validation fleet-wide (upstream returns broken signatures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Static /etc/resolv.conf on dns-?? hosts interleaves IPv6/IPv4 nameservers (offset so adjacent lines are never the same physical host) instead of listing all IPv6 first, so glibc's 3-line limit still gives 3 different hosts instead of only IPv6 ones
 - Exclude temporary and deprecated-flagged addresses from IPv4/IPv6 detection on the primary interface, so a rotating privacy-extension or expiring address never gets pinned into a static Address= line in eth0.network
 - AI instructions: pull-request-template.instructions.md no longer describes the deleted maintain-pr-description.yml automation as live; documents the actual hand-written PR description process instead
+- Disable DNSSEC validation in systemd-resolved fleet-wide (was allow-downgrade): upstream nameservers advertise DNSSEC support but return validation-breaking responses, causing fleet-wide DNS resolution failures
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script
@@ -145,6 +146,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - auto-update bash script, service, and timer — superseded by the packages role running pacman -Syyu on every hourly ansible-pull run
 ### Deployment Changes
 - Already-provisioned hosts have /etc/resolv.conf replaced (static file on dns-?? hosts, symlink to systemd-resolved's stub on every other host) and systemd-resolved restarted on their next ansible-pull run
+- Existing hosts must re-run ansible-pull (or restart systemd-resolved) to pick up the DNSSEC=no change
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->

--- a/roles/network/templates/resolved-dns.conf.j2
+++ b/roles/network/templates/resolved-dns.conf.j2
@@ -10,9 +10,14 @@ DNS={{ (network_nameservers_ipv6 + network_nameservers_ipv4) | join(' ') }}
 # from elsewhere (e.g. a future per-link Domains= from some other config).
 Domains=~.
 
-# allow-downgrade: validate DNSSEC when upstream supports it, without hard-failing
-# resolution fleet-wide if a zone's DNSSEC is broken (DNSSEC=yes would do that).
-DNSSEC=allow-downgrade
+# no: the fleet's upstream nameservers advertise DNSSEC support but return
+# responses that fail validation (e.g. "no-signature" on plain DS/A/AAAA
+# lookups) rather than genuinely not supporting it, so allow-downgrade never
+# kicks in - resolved only downgrades when a server looks like it doesn't
+# support DNSSEC at all, not when it returns broken signed-looking data.
+# That turned "com IN DS: no-signature" into fleet-wide resolution failures.
+# Disable validation outright until the upstream's DNSSEC handling is fixed.
+DNSSEC=no
 
 # LLMNR/mDNS are unauthenticated broadcast name resolution protocols and a
 # spoofing vector; unneeded since every host resolves via the nameservers above.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`nanoclaw.lan` was failing essentially all DNS resolution with
`DNSSEC validation failed: no-signature`. The fleet-wide systemd-resolved
config (`resolved-dns.conf.j2`) already used `DNSSEC=allow-downgrade`, which
only falls back to unvalidated resolution when a nameserver looks like it
doesn't support DNSSEC at all. Here the upstream nameservers advertise DNSSEC
support but return responses that fail validation (e.g. `com IN DS: no-signature`),
so allow-downgrade never kicks in and lookups hard-fail instead.

This sets `DNSSEC=no` fleet-wide so every host is unaffected by the upstream's
broken DNSSEC handling, until that upstream issue is fixed independently.

Closes #187.

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

  Live-patched `/etc/systemd/resolved.conf.d/10-dns-servers.conf` on `nanoclaw.lan`
  (the affected host) with the same `DNSSEC=no` change, restarted `systemd-resolved`,
  and confirmed `resolvectl query google.com` / `github.com` resolve successfully again.

  The test VM (`arch-vm-test.lan`) was unreachable (SSH connection timed out) at the
  time of this change, so the role/template change itself was not re-applied there via
  `ansible-pull`/`ansible-playbook`. The template diff is a single-line value change
  with no logic changes, and the identical resulting config was validated live on
  `nanoclaw.lan` above.

## Types of changes

<!--- What types of changes does your code introduce? --->
<!--- Put an 'x' in all the boxes that apply: --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [x] Requires deployment configuration changes as specified below and in CHANGELOG.md

Every already-provisioned host (except `dns-??` hosts, which use a static
`/etc/resolv.conf` instead) needs its next `ansible-pull` run (or a manual
`systemctl restart systemd-resolved` after re-templating) to pick up `DNSSEC=no`.

## Checklist

<!--- Go over all the following points, and put an 'x' in all --->
<!--- the boxes once they are true. --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.