### PR TITLE
fix(network): mask systemd-resolved on DNS hosts, add dns-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Exclude temporary and deprecated-flagged addresses from IPv4/IPv6 detection on the primary interface, so a rotating privacy-extension or expiring address never gets pinned into a static Address= line in eth0.network
 - AI instructions: pull-request-template.instructions.md no longer describes the deleted maintain-pr-description.yml automation as live; documents the actual hand-written PR description process instead
 - Disable DNSSEC validation in systemd-resolved fleet-wide (was allow-downgrade): upstream nameservers advertise DNSSEC support but return validation-breaking responses, causing fleet-wide DNS resolution failures
+- Stop, disable, and mask systemd-resolved on DNS server hosts to prevent it racing the real resolver for port 53 on boot
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Set Domains=~. in the systemd-resolved global config so unqualified lookups are never suffixed with a search domain, matching the static resolv.conf's search .
 - Fail the run with a clear error if network_nameservers_ipv4 and network_nameservers_ipv6 are ever configured with different lengths, instead of silently dropping the extra entries from dns-?? hosts' resolv.conf
 - Enable Dependabot github-actions ecosystem to keep SHA-pinned action versions up to date
+- Add dns-06 to the fleet nameserver list
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -18,6 +18,7 @@ network_nameserver_suffixes:
   - "103"
   - "104"
   - "105"
+  - "106"
 
 network_nameservers_ipv4: "{{ network_nameserver_suffixes | map('regex_replace', '^', network_nameserver_prefix_ipv4) | list }}"
 network_nameservers_ipv6: "{{ network_nameserver_suffixes | map('regex_replace', '^', network_nameserver_prefix_ipv6) | list }}"

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -132,6 +132,19 @@
     mode: "0644"
   when: network_is_dns_server
 
+# masked (not just disabled) so nothing can start it by any path - manual
+# `systemctl start`, another unit's Wants=/Requires=, or socket activation -
+# which matters here because the box's actual DNS resolver also wants port
+# 53/127.0.0.53, and a stray resolved start would race it for that port on
+# every boot.
+- name: Stop, disable and mask systemd-resolved on DNS server hosts
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    state: stopped
+    enabled: false
+    masked: true
+  when: network_is_dns_server
+
 - name: Ensure /etc/systemd/resolved.conf.d exists
   ansible.builtin.file:
     path: /etc/systemd/resolved.conf.d


### PR DESCRIPTION
# Description
Two related network-role changes on the fleet's DNS server hosts:

1. **Mask systemd-resolved on `dns-??` hosts.** Those hosts write a static
   `/etc/resolv.conf` and deliberately never enable/start `systemd-resolved`
   (they must not point their own resolver at the fleet's DNS server list,
   which includes themselves). However, nothing ever explicitly stopped,
   disabled or masked the unit either, so it was left enabled-but-inactive
   by the base image - a boot-time race risk, since the box's actual DNS
   resolver also needs port 53 / `127.0.0.53`, and a stray `systemd-resolved`
   start (enabled unit, a dependency pulling it in, or socket activation)
   could grab that port first. This adds an explicit task, guarded by the
   existing `network_is_dns_server` fact, that stops, disables, and masks
   `systemd-resolved` on those hosts. Masking (not just disabling) is used
   so nothing can start it by any path.

2. **Add `dns-06` to the fleet nameserver list.** `network_nameserver_suffixes`
   is the single source of truth consumed by both the static resolv.conf on
   `dns-??` hosts and systemd-resolved's `DNS=` list everywhere else, so
   adding `"106"` there propagates the new server to both.

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:
  - `ansible-lint` passes clean on both changed files.
  - Not applied against the test VM (`arch-vm-test.lan`), because that VM's
    hostname does not match `dns-??`, so the `network_is_dns_server` branch
    (both the mask task and the resolv.conf template) would never fire
    there - it can only be exercised on a real DNS server host.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [x] Requires deployment configuration changes as specified below and in CHANGELOG.md
On next `ansible-pull` run: `dns-??` hosts will stop/disable/mask `systemd-resolved`, and every host's nameserver config (static resolv.conf or systemd-resolved DNS=) will include the new `dns-06` server.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.