### PR TITLE
fix(scripts): generate host keys via -A then prune, not per-type -t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - AI instructions: pull-request-template.instructions.md no longer describes the deleted maintain-pr-description.yml automation as live; documents the actual hand-written PR description process instead
 - Disable DNSSEC validation in systemd-resolved fleet-wide (was allow-downgrade): upstream nameservers advertise DNSSEC support but return validation-breaking responses, causing fleet-wide DNS resolution failures
 - Stop, disable, and mask systemd-resolved on DNS server hosts to prevent it racing the real resolver for port 53 on boot
+- Fix reset-clone-identity crashing on host key types ssh-keygen -t doesn't accept directly (e.g. mldsa44-ed25519)
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/scripts/reset-clone-identity
+++ b/scripts/reset-clone-identity
@@ -9,15 +9,17 @@
 # by design: do not run it on a machine you want to keep its current
 # machine-id / SSH host keys.
 #
-# SSH host keys generated match whatever this host's sshd is actually
-# configured to use (read from `sshd -T`, the effective merged config -
-# see roles/ssh/tasks/main.yml, which pins HostKey to ed25519 and rsa only).
-# `ssh-keygen -A` on its own would also generate ecdsa and the experimental
-# mldsa44-ed25519 hybrid key, neither of which sshd is told to use here -
-# dead private key material sitting on disk for no reason. If sshd hasn't
-# been configured with explicit HostKey directives yet (e.g. the ssh role
-# has never run on this host), fall back to `ssh-keygen -A` so the script
-# still produces a usable set of keys.
+# SSH host keys: always generate the full default set via `ssh-keygen -A`
+# (the only reliable way to get exotic/hybrid key types like the
+# experimental mldsa44-ed25519 right - ssh-keygen doesn't accept every
+# type it can produce via -A as a `-t` argument), then prune whichever
+# generated files this host's sshd isn't actually configured to use (read
+# from `sshd -T`, the effective merged config - see roles/ssh/tasks/main.yml,
+# which normally pins HostKey to ed25519 and rsa only). Left otherwise,
+# ecdsa/mldsa44-ed25519 would sit on disk as dead private key material for
+# no reason. If sshd has no explicit HostKey directives yet (e.g. the ssh
+# role has never run on this host), nothing is pruned and the full -A set
+# is kept.
 #
 # Out of scope: /etc/hostname and network config (eth0.network) - those are
 # host-specific and already handled by the network Ansible role or a manual
@@ -71,22 +73,22 @@ configured_host_keys=$(sshd -T 2>/dev/null | awk 'tolower($1) == "hostkey" {prin
 
 info "Regenerating SSH host keys..."
 rm -f /etc/ssh/ssh_host_* || die "Failed to remove existing SSH host keys"
+ssh-keygen -A || die "ssh-keygen -A failed"
 
-if [ -z "${configured_host_keys}" ]; then
-    info "No explicit HostKey directives found in sshd's config - falling back to 'ssh-keygen -A' (all default key types)"
-    ssh-keygen -A || die "ssh-keygen -A failed"
-else
+if [ -n "${configured_host_keys}" ]; then
+    info "Pruning host key types this host's sshd isn't configured to use..."
+    for generated_priv in /etc/ssh/ssh_host_*_key; do
+        [ -e "${generated_priv}" ] || continue
+        if printf '%s\n' "${configured_host_keys}" | grep -qxF "${generated_priv}"; then
+            continue
+        fi
+        info "  removing unused ${generated_priv}"
+        rm -f "${generated_priv}" "${generated_priv}.pub"
+    done
+
     while IFS= read -r hostkey_path; do
         [ -z "${hostkey_path}" ] && continue
-        keytype=$(basename "${hostkey_path}")
-        keytype=${keytype#ssh_host_}
-        keytype=${keytype%_key}
-        info "  ${hostkey_path} (${keytype})"
-        if [ "${keytype}" = "rsa" ]; then
-            ssh-keygen -t rsa -b 3072 -f "${hostkey_path}" -N "" -q || die "Failed to generate rsa host key at ${hostkey_path}"
-        else
-            ssh-keygen -t "${keytype}" -f "${hostkey_path}" -N "" -q || die "Failed to generate ${keytype} host key at ${hostkey_path}"
-        fi
+        [ -e "${hostkey_path}" ] || info "  warning: sshd expects ${hostkey_path} but 'ssh-keygen -A' did not generate it"
     done <<HOSTKEY_PATHS
 ${configured_host_keys}
 HOSTKEY_PATHS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes a real crash in `scripts/reset-clone-identity` (from #189/#190), found
by actually running it against `dns-05` in production.

`dns-05`'s `sshd -T` reported a `HostKey` for `mldsa44_ed25519` (its
`ansible-pull` hadn't converged to the fleet-standard `ed25519`+`rsa` set
yet - a separate pre-existing issue, not this script's concern). The old
logic derived a `ssh-keygen -t <type>` argument from each configured
`HostKey` filename and generated types individually. That works for
ordinary types, but `ssh-keygen -t mldsa44_ed25519` isn't a valid
invocation even though `ssh-keygen -A` knows how to produce that exact
file correctly on its own. The script died mid-run (`unknown key type
mldsa44_ed25519`), leaving `dns-05` with a regenerated `machine-id` but an
inconsistent set of host key files on disk and `sshd` never restarted -
host keys on disk no longer matched what a subsequent `sshd` reload would
expect, which could have taken `sshd` down entirely.

Now always generates the full default set via `ssh-keygen -A` first (the
only reliable way to get exotic/hybrid types right), then prunes whichever
generated files aren't in `sshd`'s actual configured `HostKey` list -
instead of reconstructing individual `-t` invocations per type.

Closes #191

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

`shellcheck` and `checkbashisms` both pass clean. The corrected logic was
then actually run end-to-end on `dns-05` in production (pasted directly,
since the buggy version had already been fetched from the previous PR) -
completed successfully: `machine-id` regenerated, exactly the three
`HostKey`-configured types (`ecdsa`, `ed25519`, `mldsa44_ed25519`) were
kept and the unrelated `rsa` file pruned, `sshd` restarted cleanly, new
fingerprints printed. This is the real-world case that broke the old
per-type `-t` logic, so it's a solid regression test in practice even
though it wasn't run against `arch-vm-test.lan`.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

No deployment configuration changes. Standalone, manually-invoked script -
not wired into `install` or any Ansible role.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
