### PR TITLE
fix(ssh): replace non-existent %H sshd token with ansible_hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Disable DNSSEC validation in systemd-resolved fleet-wide (was allow-downgrade): upstream nameservers advertise DNSSEC support but return validation-breaking responses, causing fleet-wide DNS resolution failures
 - Stop, disable, and mask systemd-resolved on DNS server hosts to prevent it racing the real resolver for port 53 on boot
 - Fix reset-clone-identity crashing on host key types ssh-keygen -t doesn't accept directly (e.g. mldsa44-ed25519)
+- Fix AuthorizedKeysCommand using non-existent %H sshd token, which broke SSH access fleet-wide on the next sshd reload
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -136,13 +136,20 @@
 # host, the first time this file is rendered fresh - it just hadn't
 # detonated yet on hosts whose sshd hadn't been reloaded since this line
 # was introduced. The real per-host hostname is baked in here at Ansible
-# render time instead (ansible_hostname, same fact used in the network
-# role's DNS-server detection) - %u is left as a genuine runtime token
-# since sshd does support per-connection username expansion.
+# render time instead - %u is left as a genuine runtime token since sshd
+# does support per-connection username expansion.
+#
+# ansible_nodename (not ansible_hostname) is used deliberately: the key
+# server expects the full dns-05.lan style value, not the domain-stripped
+# short form (ansible_hostname strips everything from the first dot -
+# that's the fact roles/network/tasks/main.yml uses for the ^dns-[0-9]{2}$
+# DNS-server check, which needs the short form; this needs the opposite).
+# ansible_nodename is the raw, unmodified /etc/hostname content - no
+# domain-stripping, no DNS lookups that could disagree with it.
 - name: Configure sshd AuthorizedKeysCommand
   ansible.builtin.copy:
     dest: /etc/ssh/sshd_config.d/10-authorizedkeyscommand.conf
-    content: "AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/{{ ansible_hostname }}/%u\n"
+    content: "AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/{{ ansible_nodename }}/%u\n"
     owner: root
     group: root
     mode: "0600"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -128,10 +128,21 @@
   notify: Reload sshd
 
 # Key lookup
+# %H is not a real sshd_config token for AuthorizedKeysCommand (the
+# documented set is %f %h %k %t %U %u - all about the connecting user;
+# %h there means home directory, not hostname, unlike client-side
+# ssh_config). Using it was a latent bug: sshd fails config validation
+# with "unknown key %H" and dies on the next reload/restart, on every
+# host, the first time this file is rendered fresh - it just hadn't
+# detonated yet on hosts whose sshd hadn't been reloaded since this line
+# was introduced. The real per-host hostname is baked in here at Ansible
+# render time instead (ansible_hostname, same fact used in the network
+# role's DNS-server detection) - %u is left as a genuine runtime token
+# since sshd does support per-connection username expansion.
 - name: Configure sshd AuthorizedKeysCommand
   ansible.builtin.copy:
     dest: /etc/ssh/sshd_config.d/10-authorizedkeyscommand.conf
-    content: "AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/%H/%u\n"
+    content: "AuthorizedKeysCommand /usr/bin/curl -s https://keys.markridgwell.com/keys/{{ ansible_hostname }}/%u\n"
     owner: root
     group: root
     mode: "0600"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`AuthorizedKeysCommand` used `%H`, expecting it to expand to the local
server's hostname. That token does not exist for this directive - the
documented set is `%f %h %k %t %U %u`, all about the connecting user
(`%h` there means home directory, not hostname - the opposite of
client-side `ssh_config`). `sshd` fails config validation with
`unknown key %H` and dies on the next reload/restart.

Confirmed this is **not** a version-skew issue: `pacman -Syu` on an
affected host reported nothing to do (latest Arch package already
installed). This line has likely never worked anywhere - it just hadn't
detonated yet on any host whose `sshd` hadn't been reloaded since it was
introduced, since a running `sshd` keeps its old in-memory config until
reloaded. Confirmed live on two unrelated hosts (`dns-05`,
`notifications.lan`) that both hard-locked SSH entirely (a failing
`AuthorizedKeysCommand` blocks every user, not just one) the moment their
`sshd` next reloaded - recoverable only via console/out-of-band access.
Every other host in the fleet is sitting on the same latent trigger,
waiting for its next reboot or `ssh`-role config change.

Bakes the real per-host hostname into the rendered config at Ansible
render time (`ansible_hostname`, the same fact already used for
DNS-server detection in the `network` role) instead of relying on a
runtime `sshd` token that doesn't exist. `%u` is left alone since it's a
genuine, valid runtime token.

Closes #193

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

`ansible-lint` passes clean on the changed file. Not run against
`arch-vm-test.lan` (down at the time) or a live host yet - reasoned
through and cross-checked against the exact live failures on `dns-05`
and `notifications.lan` that prompted this fix, and against the existing
precedent for `ansible_hostname` in `roles/network/tasks/main.yml`
(confirmed there to resolve to the short hostname, e.g. `dns-06`, not
the FQDN).

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

No manual deployment steps required - the next `ansible-pull` run on
each host will rewrite `10-authorizedkeyscommand.conf` with the correct
literal hostname and reload `sshd` cleanly. Worth keeping an eye on the
first reload across the fleet given the history here.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
