### PR TITLE
fix(network): never freeze IPv6 gateway, always accept RA + enable privacy extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Stop, disable, and mask systemd-resolved on DNS server hosts to prevent it racing the real resolver for port 53 on boot
 - Fix reset-clone-identity crashing on host key types ssh-keygen -t doesn't accept directly (e.g. mldsa44-ed25519)
 - Fix AuthorizedKeysCommand using non-existent %H sshd token, which broke SSH access fleet-wide on the next sshd reload
-- Only disable IPv6 Router Advertisement acceptance when a static IPv6 gateway was detected, so segments with no static gateway don't permanently lose their IPv6 default route
+- Always accept IPv6 Router Advertisement and never freeze a static IPv6 gateway, instead of snapshotting a live route that could permanently disappear on some segments
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Stop, disable, and mask systemd-resolved on DNS server hosts to prevent it racing the real resolver for port 53 on boot
 - Fix reset-clone-identity crashing on host key types ssh-keygen -t doesn't accept directly (e.g. mldsa44-ed25519)
 - Fix AuthorizedKeysCommand using non-existent %H sshd token, which broke SSH access fleet-wide on the next sshd reload
+- Only disable IPv6 Router Advertisement acceptance when a static IPv6 gateway was detected, so segments with no static gateway don't permanently lose their IPv6 default route
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable Dependabot github-actions ecosystem to keep SHA-pinned action versions up to date
 - Add dns-06 to the fleet nameserver list
 - Add scripts/reset-clone-identity to regenerate machine-id and SSH host keys after cloning a VM
+- Enable IPv6 privacy extensions on the primary interface, so outgoing connections prefer a rotating temporary address while pinned static addresses remain reachable for anything that needs a fixed one
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -95,19 +95,6 @@
     - not ansible_check_mode
     - network_nic.stdout | length > 0
 
-- name: Detect IPv6 gateway
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      ip -6 route show default dev {{ network_nic.stdout }} \
-        2>/dev/null | awk 'NR==1{print $3}'
-    executable: /bin/bash
-  register: network_gw6
-  changed_when: false
-  when:
-    - not ansible_check_mode
-    - network_nic.stdout | length > 0
-
 - name: Write systemd-networkd configuration for primary interface
   ansible.builtin.template:
     src: eth0.network.j2

--- a/roles/network/templates/eth0.network.j2
+++ b/roles/network/templates/eth0.network.j2
@@ -34,6 +34,15 @@ RequiredForOnline=routable
 # routing is normally designed to work.
 IPv6AcceptRA=yes
 
+# IPv6PrivacyExtensions=yes: prefer a rotating temporary address (RFC 4941)
+# for outgoing connections, reducing long-term trackability of outbound
+# traffic. The static/stable address(es) pinned below via the Address=
+# loop - including any deliberately-chosen vanity form - stay present and
+# reachable for anything that needs a fixed address (inbound connections,
+# DNS records); this only changes which address gets picked as the source
+# for connections this host initiates.
+IPv6PrivacyExtensions=yes
+
 # Address=: one line per detected address (there can be more than one per
 # family - e.g. a manually added secondary address - hence the loops below
 # rather than a single line). IPv4 addressing on this fleet is genuinely

--- a/roles/network/templates/eth0.network.j2
+++ b/roles/network/templates/eth0.network.j2
@@ -16,12 +16,26 @@ RequiredForOnline=routable
 # dead config on them; duplicating it here for every other host would only add
 # a second, redundant source of the same servers with no extra redundancy.
 
-# IPv6AcceptRA=no: the sysctl role already sets net.ipv6.conf.default.accept_ra=0
+{% if network_gw6.stdout | length > 0 %}
+# IPv6AcceptRA=no: a static IPv6 gateway was detected on this interface (see
+# the Gateway= line derived from network_gw6 below), so RA is redundant -
+# and the sysctl role already sets net.ipv6.conf.default.accept_ra=0
 # fleet-wide, but systemd-networkd overrides that per-interface with its own
 # default (effectively "yes" for a non-forwarding host) once it manages a
 # link. Pinning it here explicitly makes sure RA acceptance actually stays
 # off on this interface instead of silently being re-enabled by networkd.
 IPv6AcceptRA=no
+{% else %}
+# IPv6AcceptRA=yes: no static IPv6 gateway was detected on this interface -
+# this segment's default route only exists via Router Advertisement (some
+# segments have no static gateway address at all, unlike others in this
+# fleet). Forcing IPv6AcceptRA=no here would kill that route with nothing to
+# fall back on, and worse: every subsequent run's "Address=" detection above
+# would then find no live default route to capture as a static Gateway=
+# either, permanently locking the host out of any IPv6 default route from
+# then on. Leave RA acceptance on for hosts that depend on it.
+IPv6AcceptRA=yes
+{% endif %}
 
 # Address=: one line per detected address (there can be more than one per
 # family - e.g. a manually added secondary address - hence the loops below

--- a/roles/network/templates/eth0.network.j2
+++ b/roles/network/templates/eth0.network.j2
@@ -16,30 +16,29 @@ RequiredForOnline=routable
 # dead config on them; duplicating it here for every other host would only add
 # a second, redundant source of the same servers with no extra redundancy.
 
-{% if network_gw6.stdout | length > 0 %}
-# IPv6AcceptRA=no: a static IPv6 gateway was detected on this interface (see
-# the Gateway= line derived from network_gw6 below), so RA is redundant -
-# and the sysctl role already sets net.ipv6.conf.default.accept_ra=0
-# fleet-wide, but systemd-networkd overrides that per-interface with its own
-# default (effectively "yes" for a non-forwarding host) once it manages a
-# link. Pinning it here explicitly makes sure RA acceptance actually stays
-# off on this interface instead of silently being re-enabled by networkd.
-IPv6AcceptRA=no
-{% else %}
-# IPv6AcceptRA=yes: no static IPv6 gateway was detected on this interface -
-# this segment's default route only exists via Router Advertisement (some
-# segments have no static gateway address at all, unlike others in this
-# fleet). Forcing IPv6AcceptRA=no here would kill that route with nothing to
-# fall back on, and worse: every subsequent run's "Address=" detection above
-# would then find no live default route to capture as a static Gateway=
-# either, permanently locking the host out of any IPv6 default route from
-# then on. Leave RA acceptance on for hosts that depend on it.
+# IPv6AcceptRA=yes: IPv6 gateways on this fleet are only ever handed out via
+# Router Advertisement - there is no static IPv6 gateway anywhere to freeze
+# into a Gateway= line below (see the IPv6 Address= loop: addresses are
+# detected and pinned as static, but no IPv6 Gateway= is ever written, on
+# purpose). An earlier version of this file tried to snapshot whatever
+# default route happened to be live at Ansible-run time into a static
+# Gateway=, then disable RA acceptance on the assumption the snapshot would
+# always be there to replace it. That's fragile in both directions: any run
+# that happens to catch the interface before RA has populated a route
+# (freshly booted VM, brief network blip, etc.) freezes nothing, and once
+# nothing is captured while RA is also disabled, the host is permanently
+# locked out of any IPv6 default route with no way to self-heal (confirmed
+# live on proxy.lan). Leaving RA acceptance on and never writing an IPv6
+# Gateway= sidesteps the whole class of failure: the default route stays
+# whatever RA says it is, continuously, for every host, the way IPv6
+# routing is normally designed to work.
 IPv6AcceptRA=yes
-{% endif %}
 
 # Address=: one line per detected address (there can be more than one per
 # family - e.g. a manually added secondary address - hence the loops below
-# rather than a single line).
+# rather than a single line). IPv4 addressing on this fleet is genuinely
+# static (no DHCP), so - unlike IPv6 above - a detected IPv4 default
+# gateway is still pinned as a static Gateway= line.
 {% for addr in network_ipv4.stdout_lines %}
 Address={{ addr }}
 {% endfor %}
@@ -49,7 +48,3 @@ Gateway={{ network_gw4.stdout }}
 {% for addr in network_ipv6.stdout_lines %}
 Address={{ addr }}
 {% endfor %}
-{% if network_gw6.stdout | length > 0 %}
-
-Gateway={{ network_gw6.stdout }}
-{% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Two related IPv6 changes to `eth0.network.j2`, from the same investigation.

## Never freeze a static IPv6 gateway, always accept RA

`IPv6AcceptRA=no` was unconditional. On segments with no static IPv6
gateway (default route only ever exists via Router Advertisement -
confirmed live on `proxy.lan`: `proto ra` with a hard expiry), this was
self-perpetuating: the first run kills the RA-learned route, and every
subsequent run's gateway detection then finds no live default route to
capture as a static `Gateway=` either - since RA is now off and there was
never a static one - permanently locking the host out of any IPv6 default
route with no way to self-heal. Confirmed live: the on-disk file had
`IPv6AcceptRA=no` and no IPv6 `Gateway=` line at all; manually flipping it
back to `Yes` immediately restored a working (RA-learned) default route.

Rather than a narrower conditional fix (only disable RA when a gateway was
captured), went with the simpler and more robust version: IPv6 gateways on
this fleet are only ever handed out via RA, there's no static one anywhere
worth snapshotting in the first place. `IPv6AcceptRA` is now unconditionally
`yes`, no IPv6 `Gateway=` line is ever written, and the now-unused "Detect
IPv6 gateway" task is removed entirely. IPv4 is unchanged (genuinely static
addressing, no DHCP, so a detected gateway is still pinned).

Closes #195

## Enable IPv6 privacy extensions

`IPv6PrivacyExtensions=yes` prefers a rotating temporary address (RFC 4941)
for outgoing connections, reducing long-term trackability of outbound
traffic, while the static/stable addresses already pinned via the existing
`Address=` detection - including deliberately-chosen vanity forms like
`2a02:8010:61d5:150::250` - stay present and reachable for anything that
needs a fixed address (inbound connections, DNS records).

Closes #197

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

`ansible-lint` passes clean. Both changes rendered directly with Jinja2
(standalone script) to confirm valid, correctly-structured `.network`
output. The gateway-freeze root cause was confirmed live on `proxy.lan`
before the fix (missing `Gateway=`, `IPv6AcceptRA=no`, dead RA-learned
route) and the manual workaround (`IPv6AcceptRA=yes`) verified to restore
connectivity. Not yet re-run through `ansible-pull` end-to-end to confirm
the final templated output matches on a live host.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

No manual deployment steps required - the next `ansible-pull` run on each
host re-renders `eth0.network` with both changes and reloads networking.
Hosts already stuck with no IPv6 default route (like `proxy.lan` was
before the manual workaround) will self-heal on their next run.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
