### PR TITLE
fix(packages): stop a Chaotic AUR keyserver outage blocking the network role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Fix reset-clone-identity crashing on host key types ssh-keygen -t doesn't accept directly (e.g. mldsa44-ed25519)
 - Fix AuthorizedKeysCommand using non-existent %H sshd token, which broke SSH access fleet-wide on the next sshd reload
 - Always accept IPv6 Router Advertisement and never freeze a static IPv6 gateway, instead of snapshotting a live route that could permanently disappear on some segments
+- Make Chaotic AUR key fetch idempotent and non-fatal so a keyserver outage can no longer block the network/DNS role from applying
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -8,29 +8,65 @@
     insertafter: "^Include = /etc/pacman.d/mirrorlist$"
     state: present
 
-- name: Receive Chaotic AUR signing key
+- name: Check if Chaotic AUR signing key is already trusted
   ansible.builtin.command:
-    cmd: >-
-      pacman-key --recv-key 3056513887B78AEB
-      --keyserver hkps://keyserver.ubuntu.com
-  changed_when: true
+    cmd: pacman-key --list-keys 3056513887B78AEB
+  register: packages_chaotic_key_check
+  changed_when: false
+  failed_when: false
 
-- name: Locally sign Chaotic AUR key
-  ansible.builtin.command:
-    cmd: pacman-key --lsign-key 3056513887B78AEB
-  changed_when: true
+# Everything Chaotic-AUR-specific lives in this block so a keyserver outage
+# can't take the rest of the play down with it. Before this, "Receive
+# Chaotic AUR signing key" ran unconditionally (no retries, nothing catching
+# a failure) as the very first task ahead of the network role - one bad
+# hkps://keyserver.ubuntu.com lookup aborted the whole run and the host
+# never got as far as the network role, silently going stale on DNS/network
+# config (confirmed: docker-registry.lan failed here on 690 of its last 692
+# hourly pulls). The key-presence check above means most runs skip hitting
+# the keyserver at all once the key is trusted once; the retries below give
+# a fresh host a few chances against a flaky keyserver; the rescue means
+# that if it's still down, this run just skips Chaotic AUR and moves on
+# instead of failing the play.
+- name: Set up Chaotic AUR signing key and repository
+  when: packages_chaotic_key_check.rc != 0
+  block:
+    - name: Receive Chaotic AUR signing key
+      ansible.builtin.command:
+        cmd: >-
+          pacman-key --recv-key 3056513887B78AEB
+          --keyserver hkps://keyserver.ubuntu.com
+      register: packages_chaotic_key_receive
+      until: packages_chaotic_key_receive.rc == 0
+      retries: 3
+      delay: 10
+      changed_when: true
+
+    - name: Locally sign Chaotic AUR key
+      ansible.builtin.command:
+        cmd: pacman-key --lsign-key 3056513887B78AEB
+      changed_when: true
+  rescue:
+    - name: Warn that the Chaotic AUR key could not be trusted this run
+      ansible.builtin.debug:
+        msg: >-
+          Could not receive/trust the Chaotic AUR signing key this run
+          (keyserver unreachable?). Skipping Chaotic AUR setup for now -
+          the rest of the play, including the network role, still runs.
+          This will retry automatically on the next ansible-pull.
 
 - name: Install Chaotic AUR keyring
   community.general.pacman:
     name: https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst
     state: present
     extra_args: "--noconfirm --needed"
+  when: packages_chaotic_key_check.rc == 0 or packages_chaotic_key_receive.rc | default(1) == 0
 
 - name: Install Chaotic AUR mirrorlist
   community.general.pacman:
     name: https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst  # yamllint disable-line rule:line-length
     state: present
     extra_args: "--noconfirm --needed"
+  when: packages_chaotic_key_check.rc == 0 or packages_chaotic_key_receive.rc | default(1) == 0
 
 - name: Remove any unmanaged chaotic-aur section from pacman.conf
   ansible.builtin.shell:
@@ -74,6 +110,7 @@
       Include = /etc/pacman.d/chaotic-mirrorlist
       CacheServer = https://pacman.markridgwell.com/repo/chaotic-aur/x86_64
     state: present
+  when: packages_chaotic_key_check.rc == 0 or packages_chaotic_key_receive.rc | default(1) == 0
 
 - name: Update all packages
   community.general.pacman:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The "Receive Chaotic AUR signing key" task in `roles/packages/tasks/main.yml`
ran unconditionally on every `ansible-pull` (no idempotency check, no
retries, no error handling), fetching from `hkps://keyserver.ubuntu.com` as
the very first role in `site.yml` - well before the `network` role. Any
transient keyserver failure aborted the whole play before the `network`
role ever ran.

Confirmed live on `docker-registry.lan`: 690 of the last 692 hourly
ansible-pull runs (30 days) failed at exactly this task, leaving that host
unable to receive any config change from this repo, including DNS/network
fixes - it was still running a pre-migration nameserver list from before
`network_nameserver_suffixes` existed.

This change:

- Adds a `pacman-key --list-keys` check so most runs skip the keyserver
  entirely once the key is already trusted.
- Wraps the fetch/sign/install-keyring/install-mirrorlist/repo-config tasks
  in a `block`.
- Adds `retries`/`delay`/`until` to the key-fetch task for resilience
  against a flaky keyserver.
- Adds a `rescue` that logs a warning and lets the rest of the play,
  including the `network` role, continue instead of aborting.

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

`yamllint` and `ansible-lint` (production profile) pass against the changed
file. `ansible-playbook --syntax-check` could not be run in this sandbox
(tool restricted by local policy). Not yet run against the test VM
(`arch-vm-test.lan`) - recommend doing so before/while merging, per this
repo's testing instructions.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
