### PR TITLE
feat(telegraf): report to monitoring via Telegraf; default container_runtime to docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Add dns-06 to the fleet nameserver list
 - Add scripts/reset-clone-identity to regenerate machine-id and SSH host keys after cloning a VM
 - Enable IPv6 privacy extensions on the primary interface, so outgoing connections prefer a rotating temporary address while pinned static addresses remain reachable for anything that needs a fixed one
+- Install and configure Telegraf to report host and container metrics to https://metrics.markridgwell.com
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Derive the fleet nameserver IPv4/IPv6 address lists from a single list of host suffixes plus fixed prefixes, instead of two independently hand-maintained lists, so they can no longer drift out of sync in length or content
 - Order systemd-resolved's global DNS= as IPv6 nameservers before IPv4, matching the static resolv.conf's ordering
 - Bumped aws-actions/configure-aws-credentials from 6.2.2 to 6.2.3 (bug fixes: PackedPolicyTooLarge detection in STS tags, git credentials attached before Tag Major Version push)
+- Default container_runtime to docker instead of podman for new and existing VMs
 ### Deprecated
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Sets up an Arch Linux VM with Docker, Git, and supporting tooling. The `install`
 - **pkgstats** — weekly anonymous package statistics submission
 - **reflector** — automatic mirror ranking
 - **pacman cache pruning** — weekly `paccache -r` via systemd timer
+- **Telegraf** — reports host and (on Docker hosts) container metrics to `https://metrics.markridgwell.com`
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/credfeto/credfeto-setup-arch-vm/refs/heads/main/install | sh

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
 # container_runtime controls which container engine is installed.
-# Use 'podman' for new VMs (default). Set to 'docker' for existing Docker hosts.
-container_runtime: podman
+# Use 'docker' for new VMs (default). Set to 'podman' for existing Podman hosts.
+container_runtime: docker

--- a/roles/telegraf/handlers/main.yml
+++ b/roles/telegraf/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart telegraf
+  ansible.builtin.systemd:
+    name: telegraf
+    state: restarted

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Install telegraf package
+  community.general.pacman:
+    name: telegraf
+    state: present
+    extra_args: "--noconfirm --needed"
+
+- name: Deploy telegraf configuration
+  ansible.builtin.template:
+    src: telegraf.conf.j2
+    dest: /etc/telegraf/telegraf.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart telegraf
+
+# The telegraf system user/group is created by the package above, so this
+# must run after the install task. Only needed when container_runtime is
+# docker: telegraf.conf's [[inputs.docker]] block (see telegraf.conf.j2) is
+# itself gated on the same condition, so there is nothing for telegraf to
+# read from the docker socket on podman hosts.
+- name: Add telegraf user to docker group for Docker stats collection
+  ansible.builtin.user:
+    name: telegraf
+    groups: docker
+    append: true
+  when: container_runtime == 'docker'
+
+- name: Enable and start telegraf service
+  ansible.builtin.systemd:
+    name: telegraf
+    enabled: true
+    state: started

--- a/roles/telegraf/templates/telegraf.conf.j2
+++ b/roles/telegraf/templates/telegraf.conf.j2
@@ -1,0 +1,54 @@
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  hostname = ""
+  omit_hostname = false
+
+[[outputs.influxdb]]
+  urls = ["https://metrics.markridgwell.com"]
+  database = "telegraf"
+  skip_database_creation = true
+  timeout = "5s"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = false
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
+[[inputs.diskio]]
+
+[[inputs.mem]]
+
+[[inputs.net]]
+
+[[inputs.system]]
+
+{# Only rootful Docker exposes a compatible unix:///var/run/docker.sock.
+   Podman hosts have no such socket by default, so this whole block is
+   skipped there rather than deployed and left to fail every gather
+   interval; kept in sync with the container_runtime gating used throughout
+   roles/docker, roles/podman, roles/services and roles/firewall. #}
+{% if container_runtime == 'docker' %}
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"
+  gather_services = false
+  container_names = []
+  source_tag = false
+  container_name_include = []
+  container_name_exclude = []
+  timeout = "5s"
+  perdevice = true
+  total = false
+  docker_label_include = []
+  docker_label_exclude = []
+{% endif %}

--- a/site.yml
+++ b/site.yml
@@ -20,4 +20,5 @@
     - services
     - ansible_pull
     - audit
+    - telegraf
     - reboot


### PR DESCRIPTION
## Summary

- Adds `roles/telegraf/` to install and configure Telegraf on every VM, mirroring `../credfeto-monitoring/client/Telegraf/{install.sh,configure.sh,telegraf.conf}` as an idempotent Ansible role. Wired into `site.yml`.
- `telegraf.conf.j2`'s `[[inputs.docker]]` block only renders when `container_runtime == 'docker'` (matches the gating already used in `roles/docker`, `roles/podman`, `roles/services`, `roles/firewall` - avoids a permanent gather error on podman hosts, which have no `docker.sock`).
- `group_vars/all.yml`: `container_runtime` default flipped from `podman` to `docker`, per explicit direction in the linked issue. Scope is limited to the default value - no podman removal/cleanup is included.
- README + CHANGELOG updated.

Closes #200

## Test plan

- [x] `ansible-lint` passed (via the repo's pre-commit hook, twice - once per commit).
- [x] Full pre-commit baseline passed on both commits.
- [ ] **Not validated against `arch-vm-test.lan`.** Per `ai/local/testing.instructions.md`, changes to Ansible roles should be applied to the test VM before merging. This sandbox could not reach `arch-vm-test.lan:22` (`Connection timed out`) - no network path from this environment. Needs a run from an environment with access:
  ```sh
  ansible-playbook -i arch-vm-test.lan, site.yml --tags telegraf
  ```