### PR TITLE
fix(network): only pin static IPv6 addresses in eth0.network, not SLAAC ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Order systemd-resolved's global DNS= as IPv6 nameservers before IPv4, matching the static resolv.conf's ordering
 - Bumped aws-actions/configure-aws-credentials from 6.2.2 to 6.2.3 (bug fixes: PackedPolicyTooLarge detection in STS tags, git credentials attached before Tag Major Version push)
 - Default container_runtime to docker instead of podman for new and existing VMs
+- Only pin manually-assigned (non-dynamic) IPv6 addresses into eth0.network's static Address= list; SLAAC-assigned addresses, stable and temporary alike, are left entirely to the kernel/router advertisements
 ### Deprecated
 ### Removed
 - Remove criu and pigz packages — neither is used or configured by the script

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -79,14 +79,25 @@
     - not ansible_check_mode
     - network_nic.stdout | length > 0
 
-# temporary/deprecated address flags are excluded: see the comment above the
-# IPv4 equivalent task.
+# Unlike IPv4, only genuinely static IPv6 addresses are pinned here - e.g. a
+# manually-assigned vanity address such as 2a02:8010:61d5:42::102. Anything
+# the kernel assigned itself via SLAAC/RA is flagged "dynamic" by `ip addr
+# show`, whether it's the stable/permanent address or a rotating
+# privacy-extension one, and is filtered out here on that flag alone (which
+# subsumes the temporary/deprecated flags used above for IPv4 - both of
+# those only ever appear on dynamic addresses anyway). That leaves every
+# SLAAC-derived address entirely under kernel/RA control, matching
+# IPv6AcceptRA=yes and IPv6PrivacyExtensions=yes in eth0.network.j2: nothing
+# pinned here fights with what the kernel is managing on its own. A static
+# Address= line, once applied by systemd-networkd, is itself non-dynamic, so
+# a vanity address pinned by an earlier run is correctly detected and kept
+# on every subsequent run.
 - name: Detect IPv6 addresses
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
       ip -o -6 addr show dev {{ network_nic.stdout }} scope global \
-        | awk '{skip=0; for (i=5; i<=NF; i++) if ($i=="temporary" || $i=="deprecated") skip=1; if (!skip) print $4}' \
+        | awk '{skip=0; for (i=5; i<=NF; i++) if ($i=="dynamic" || $i=="temporary" || $i=="deprecated") skip=1; if (!skip) print $4}' \
         | sort -V
     executable: /bin/bash
   register: network_ipv6

--- a/roles/network/templates/eth0.network.j2
+++ b/roles/network/templates/eth0.network.j2
@@ -36,17 +36,20 @@ IPv6AcceptRA=yes
 
 # IPv6PrivacyExtensions=yes: prefer a rotating temporary address (RFC 4941)
 # for outgoing connections, reducing long-term trackability of outbound
-# traffic. The static/stable address(es) pinned below via the Address=
-# loop - including any deliberately-chosen vanity form - stay present and
-# reachable for anything that needs a fixed address (inbound connections,
-# DNS records); this only changes which address gets picked as the source
-# for connections this host initiates.
+# traffic. Only genuinely static addresses - e.g. a deliberately-chosen
+# vanity address - are ever pinned below via the Address= loop; every
+# SLAAC-assigned address, including the kernel's own stable/permanent one,
+# is left entirely to the kernel/RA to manage. A pinned static address
+# stays present and reachable for anything that needs a fixed address
+# (inbound connections, DNS records); this setting only changes which
+# address gets picked as the source for connections this host initiates.
 IPv6PrivacyExtensions=yes
 
 # Address=: one line per detected address (there can be more than one per
-# family - e.g. a manually added secondary address - hence the loops below
-# rather than a single line). IPv4 addressing on this fleet is genuinely
-# static (no DHCP), so - unlike IPv6 above - a detected IPv4 default
+# family - e.g. a manually added secondary/vanity address - hence the loops
+# below rather than a single line). IPv4 addressing on this fleet is
+# genuinely static (no DHCP), so - unlike IPv6 above, where only
+# non-dynamic addresses are detected and pinned - a detected IPv4 default
 # gateway is still pinned as a static Gateway= line.
 {% for addr in network_ipv4.stdout_lines %}
 Address={{ addr }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The IPv6 address detection task in the `network` role previously pinned every
global IPv6 address on the primary interface that wasn't flagged
`temporary`/`deprecated` into `eth0.network`'s static `Address=` lines. That
included the kernel's own SLAAC-assigned stable/permanent address, not just a
manually-assigned vanity address.

This changes the filter to include only addresses lacking the kernel's
`dynamic` flag (which subsumes `temporary`/`deprecated`, since both only ever
appear on dynamic addresses). Now only genuinely static/manual addresses -
e.g. a deliberately-chosen vanity address like `2a02:8010:61d5:42::102` - get
pinned. Every SLAAC-derived address, stable or rotating, is left entirely
under kernel/RA control, matching the existing `IPv6AcceptRA=yes` and
`IPv6PrivacyExtensions=yes` settings.

Closes #207

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

Tested against the `arch-vm-test.lan` test VM:

1. Added a fake static (non-dynamic) IPv6 address, `2a02:8010:61d5:150::99/64`,
   alongside the VM's existing SLAAC-assigned addresses (one stable, flagged
   `dynamic mngtmpaddr`; one rotating, flagged `temporary dynamic`).
2. Ran `ansible-pull -C fix/207-ipv6-static-only-address-pinning site.yml` - completed
   with `failed=0`. Confirmed `/etc/systemd/network/eth0.network` pinned only the
   static test address; neither SLAAC address appeared.
3. Re-ran the same pull - the `Write systemd-networkd configuration for primary
   interface` task reported `ok` (not `changed`), confirming idempotency.
4. Removed the fake static address and re-ran - confirmed no stale `Address=` line
   was left behind.
5. Restored the VM to track `main` and re-ran to leave it clean for the next test.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [x] Requires deployment configuration changes as specified below and in CHANGELOG.md

Any host with a manually-assigned static/vanity IPv6 address keeps it pinned as
before. Any host whose only pinned IPv6 address was actually SLAAC-assigned
(rather than manual) will have that `Address=` line dropped from `eth0.network`
on the next `ansible-pull` run - the kernel will keep providing that same
address via SLAAC, so this is not expected to cause any connectivity change,
but it's a real change to what's on disk.

## Checklist

- [x] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
