### PR TITLE
feat(shell): configure system-wide coloured Starship bash prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Enable IPv6 privacy extensions on the primary interface, so outgoing connections prefer a rotating temporary address while pinned static addresses remain reachable for anything that needs a fixed one
 - Install and configure Telegraf to report host and container metrics to https://metrics.markridgwell.com
 - Enable and start serial-getty@ttyS0.service via the services role, giving VMs a browser-copy/paste-capable serial console that keeps working when guest networking is down
+- Configure a system-wide coloured Starship prompt for all users
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/starship/files/starship.toml
+++ b/roles/starship/files/starship.toml
@@ -1,9 +1,14 @@
 # Colour theme copied from credfeto/credfeto-bash's starship.toml (that repo
-# was renamed from credfeto/mybash; the theme itself is unchanged), with one
-# deliberate deviation: [username] style_root below is recoloured (source
-# theme has style_root identical to style_user) so an interactive root shell
-# is visually unmistakable on these hardened VMs. Everything else is verbatim
-# — see credfeto/credfeto-setup-arch-vm#211 for the approved deviation.
+# was renamed from credfeto/mybash; the theme itself is unchanged), with two
+# deliberate deviations from that source file:
+#   - [username] style_root below is recoloured (source theme has style_root
+#     identical to style_user) so an interactive root shell is visually
+#     unmistakable on these hardened VMs - see
+#     credfeto/credfeto-setup-arch-vm#211 for the approved deviation.
+#   - [docker_context] format wraps $path inside the ($style) group; the
+#     source theme leaves it outside, which renders it unstyled and breaks
+#     the powerline colour bar - a formatting bug fix, not a theme change.
+# Everything else is verbatim.
 format = """
 [](#3B4252)\
 $hostname\
@@ -73,7 +78,9 @@ format = '[ $symbol ($version) ]($style)'
 [docker_context]
 symbol = " "
 style = "bg:#06969A"
-format = '[ $symbol $context ]($style) $path'
+# $path pulled inside the ($style) group (upstream credfeto-bash leaves it
+# outside, which renders it unstyled and breaks the powerline colour bar)
+format = '[ $symbol $context $path ]($style)'
 
 [elixir]
 symbol = " "

--- a/roles/starship/files/starship.toml
+++ b/roles/starship/files/starship.toml
@@ -1,0 +1,136 @@
+# Colour theme copied from credfeto/credfeto-bash's starship.toml (that repo
+# was renamed from credfeto/mybash; the theme itself is unchanged), with one
+# deliberate deviation: [username] style_root below is recoloured (source
+# theme has style_root identical to style_user) so an interactive root shell
+# is visually unmistakable on these hardened VMs. Everything else is verbatim
+# — see credfeto/credfeto-setup-arch-vm#211 for the approved deviation.
+format = """
+[](#3B4252)\
+$hostname\
+$username\
+[](bg:#434C5E fg:#3B4252)\
+$directory\
+[](fg:#434C5E bg:#4C566A)\
+$git_branch\
+$git_status\
+[](fg:#4C566A bg:#86BBD8)\
+$c\
+$elixir\
+$elm\
+$golang\
+$haskell\
+$java\
+$julia\
+$nodejs\
+$nim\
+$rust\
+[](fg:#86BBD8 bg:#06969A)\
+$docker_context\
+[](fg:#06969A bg:#33658A)\
+$time\
+[ ](fg:#33658A)\
+"""
+command_timeout = 5000
+# Disable the blank line at the start of the prompt
+# add_newline = false
+
+# You can also replace your username with a neat symbol like  to save some space
+[username]
+show_always = true
+style_user = "bg:#3B4252"
+style_root = "bold bg:#BF616A"
+format = '[$user ]($style)'
+
+[hostname]
+ssh_only = true
+style = "bg:#3B4252"
+format = '[$hostname:]($style)'
+
+[directory]
+style = "bg:#434C5E"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+# Here is how you can shorten some long paths by text replacement
+# similar to mapped_locations in Oh My Posh:
+[directory.substitutions]
+"Documents" = " "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+# Keep in mind that the order matters. For example:
+# "Important Documents" = "  "
+# will not be replaced, because "Documents" was already substituted before.
+# So either put "Important Documents" before "Documents" or use the substituted version:
+# "Important  " = "  "
+
+[c]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[docker_context]
+symbol = " "
+style = "bg:#06969A"
+format = '[ $symbol $context ]($style) $path'
+
+[elixir]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[elm]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[git_branch]
+symbol = ""
+style = "bg:#4C566A"
+format = '[ $symbol $branch ]($style)'
+
+[git_status]
+style = "bg:#4C566A"
+format = '[$all_status$ahead_behind ]($style)'
+
+[golang]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[haskell]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[java]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[julia]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[nodejs]
+symbol = ""
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[nim]
+symbol = " "
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[rust]
+symbol = ""
+style = "fg:#434C5E bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[time]
+disabled = false
+time_format = "%R" # Hour:Minute Format
+style = "bg:#33658A"
+format = '[ $time ]($style)'

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -17,15 +17,27 @@
 # own compiled-in SYS_BASHRC behaviour) and login interactive shells (Arch's
 # /etc/profile explicitly sources it whenever $PS1 is set) - this one file
 # covers every interactive bash shell for every user, present and future.
-# It's a pacman-owned config file: a .pacnew may appear on package upgrade,
-# same accepted behaviour as the pacman.conf blockinfile in roles/packages.
+# It's a pacman-owned config file: a .pacnew may appear on package upgrade -
+# roles/packages accepts the same risk for its pacman.conf blockinfile,
+# though that one also has a companion cleanup task for unmanaged sections
+# that this block doesn't need (nothing else ever writes to this marker).
 - name: Enable Starship prompt for all users via system-wide bash.bashrc
   ansible.builtin.blockinfile:
     path: /etc/bash.bashrc
     marker: "# {mark} ANSIBLE MANAGED BLOCK - starship"
     block: |
-      # Default only - a user's own ~/.config/starship.toml still wins if present
-      export STARSHIP_CONFIG="${STARSHIP_CONFIG:-/etc/starship.toml}"
-      # Guarded so a failed/pending package install can't break every login
-      command -v starship >/dev/null 2>&1 && eval "$(starship init bash)"
+      # Whole block guarded: a failed/pending package install can't break
+      # every login, and nothing gets exported into the environment for
+      # a starship that isn't there to use it.
+      if command -v starship >/dev/null 2>&1; then
+        # Only set the system default when the user has no config of their
+        # own and nothing upstream already set STARSHIP_CONFIG (e.g. via
+        # SSH env forwarding) - starship's own unset-vs-set precedence is
+        # what actually governs the per-user override, so this must not
+        # clobber it, or ~/.config/starship.toml would be silently ignored.
+        if [ -z "${STARSHIP_CONFIG:-}" ] && [ ! -f "${XDG_CONFIG_HOME:-$HOME/.config}/starship.toml" ]; then
+          export STARSHIP_CONFIG=/etc/starship.toml
+        fi
+        eval "$(starship init bash)"
+      fi
     state: present

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Install starship
+  community.general.pacman:
+    name: starship
+    state: present
+    extra_args: "--noconfirm --needed"
+
+- name: Install system-wide Starship prompt configuration
+  ansible.builtin.copy:
+    src: starship.toml
+    dest: /etc/starship.toml
+    owner: root
+    group: root
+    mode: "0644"
+
+# /etc/bash.bashrc is sourced for both non-login interactive shells (bash's
+# own compiled-in SYS_BASHRC behaviour) and login interactive shells (Arch's
+# /etc/profile explicitly sources it whenever $PS1 is set) - this one file
+# covers every interactive bash shell for every user, present and future.
+# It's a pacman-owned config file: a .pacnew may appear on package upgrade,
+# same accepted behaviour as the pacman.conf blockinfile in roles/packages.
+- name: Enable Starship prompt for all users via system-wide bash.bashrc
+  ansible.builtin.blockinfile:
+    path: /etc/bash.bashrc
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - starship"
+    block: |
+      # Default only - a user's own ~/.config/starship.toml still wins if present
+      export STARSHIP_CONFIG="${STARSHIP_CONFIG:-/etc/starship.toml}"
+      # Guarded so a failed/pending package install can't break every login
+      command -v starship >/dev/null 2>&1 && eval "$(starship init bash)"
+    state: present

--- a/roles/starship/tasks/main.yml
+++ b/roles/starship/tasks/main.yml
@@ -30,14 +30,32 @@
       # every login, and nothing gets exported into the environment for
       # a starship that isn't there to use it.
       if command -v starship >/dev/null 2>&1; then
-        # Only set the system default when the user has no config of their
-        # own and nothing upstream already set STARSHIP_CONFIG (e.g. via
-        # SSH env forwarding) - starship's own unset-vs-set precedence is
-        # what actually governs the per-user override, so this must not
-        # clobber it, or ~/.config/starship.toml would be silently ignored.
-        if [ -z "${STARSHIP_CONFIG:-}" ] && [ ! -f "${XDG_CONFIG_HOME:-$HOME/.config}/starship.toml" ]; then
-          export STARSHIP_CONFIG=/etc/starship.toml
+        # Resolve the real home directory from the effective UID rather
+        # than $HOME - `sudo -s`/`sudo bash` (unlike `sudo -i`/`su -`)
+        # does not reset HOME on Arch's default sudoers, so a root shell
+        # reached that way would otherwise check the invoking user's
+        # config instead of root's, silently losing the distinct root
+        # styling this file exists to guarantee.
+        _starship_home=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)
+        _starship_config_dir="${XDG_CONFIG_HOME:-${_starship_home:-$HOME}/.config}"
+        # Only set/keep the system default when the user has no config of
+        # their own - starship's own unset-vs-set precedence is what
+        # actually governs the per-user override, so this must not
+        # clobber it, or ~/.config/starship.toml would be silently
+        # ignored. _STARSHIP_DEFAULTED marks a default *this block* set
+        # (as opposed to one set upstream, e.g. via SSH env forwarding,
+        # which is left alone) so a config created after this variable
+        # was already exported into a parent shell is still picked up by
+        # every new shell, not just a fresh login.
+        if [ -z "${STARSHIP_CONFIG:-}" ] || [ -n "${_STARSHIP_DEFAULTED:-}" ]; then
+          if [ -f "${_starship_config_dir}/starship.toml" ]; then
+            unset STARSHIP_CONFIG _STARSHIP_DEFAULTED
+          else
+            export STARSHIP_CONFIG=/etc/starship.toml
+            export _STARSHIP_DEFAULTED=1
+          fi
         fi
+        unset _starship_home _starship_config_dir
         eval "$(starship init bash)"
       fi
     state: present

--- a/site.yml
+++ b/site.yml
@@ -7,6 +7,7 @@
   roles:
     - packages
     - users
+    - starship
     - sysctl
     - kernel_modules
     - proc


### PR DESCRIPTION
## Summary

Adds a new `starship` Ansible role that configures a system-wide, coloured Starship bash prompt for all users on the VM.

- Installs `starship` from the official `extra` repo.
- Deploys the `credfeto/credfeto-bash` colour theme (verbatim, minus that repo's `.bashrc` aliases - only the prompt) to `/etc/starship.toml`.
- Wires it into every interactive bash shell via a guarded `blockinfile` block in `/etc/bash.bashrc` (covers both login and non-login interactive shells on Arch, confirmed from `/etc/profile`'s own sourcing behaviour).
- Root gets a distinct bold-red segment instead of matching a normal user's colour - approved deviation from the source theme, see issue discussion.

Closes #211

## Test plan

Verified against `arch-vm-test.lan` via `ansible-pull` on this branch:
- First run: `failed=0`; `starship` installed, `/etc/starship.toml` deployed (root:root 644), managed block present in `/etc/bash.bashrc`.
- Confirmed rendered prompt colours directly with `starship prompt`: normal user grey (`#3B4252`), root bold red (`#BF616A`).
- Second run: `failed=0`, all three `starship` role tasks reported `ok` (not `changed`) - idempotent. The 4 tasks that did report `changed` on the second run (Chaotic AUR mirrorlist, package updates, sysctl, network reload) are pre-existing and unrelated to this change.
- VM reverted to its pre-test baseline afterwards (package removed, config file removed, managed block stripped from `/etc/bash.bashrc`) per this repo's testing rules.
