### PR TITLE
fix(packages): restore pacman cache dir mode and purge stale download dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - telegraf.service crash-looping on start because the deployed config used removed inputs.docker fields (container_names, perdevice, total) not recognised by the installed Telegraf version
 - IPv6 traffic from Docker containers was rejected by the host firewall (docker zone only matched IPv4 sources), breaking any outbound IPv6 connection a container makes - e.g. Traefik's IPv6-routed backends
 - IPv6 default route silently expiring fleet-wide: set net.ipv6.conf.{all,default}.accept_ra to 2 instead of 0, so Router Advertisements are still accepted despite IPv6 forwarding being enabled for container networking
+- Restore pacman package cache directory to owner root, group root, mode 0755 and purge stale partial-download directories, fixing every ansible-pull run failing at the first pacman task because the DownloadUser=alpm sandbox could not traverse a permission-drifted cache directory
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -3,34 +3,56 @@
 # (including the Chaotic AUR keyring/mirrorlist pacman -U calls just below)
 # is fetched by the unprivileged "alpm" user sandboxed into a per-download
 # "download-<random>" subdirectory of the cache dir. That sandbox needs
-# execute permission on /var/cache/pacman/pkg itself to open files inside
-# it; if the directory has drifted to something tighter than the package's
-# own shipped mode (root:root 0755, confirmed via the pacman package's
-# mtree metadata), every download fails with "Permission denied" and the
-# whole play aborts here, before any later role ever runs. This must stay
-# the first task in the play (packages is the first role in site.yml) so
-# no download - including the Chaotic AUR ones below - can hit it.
-- name: Ensure pacman package cache directory has correct ownership and mode
+# execute permission on /var/cache/pacman/pkg (and its parent) to open
+# files inside it; if either directory has drifted to something tighter
+# than the package's own shipped mode (root:root 0755, confirmed via the
+# pacman package's mtree metadata), every download fails with "Permission
+# denied" and the whole play aborts here, before any later role ever runs.
+# This must stay the first task in the play (packages is the first role in
+# site.yml) so no download - including the Chaotic AUR ones below - can
+# hit it.
+- name: Ensure pacman package cache directories have correct ownership and mode
   ansible.builtin.file:
-    path: /var/cache/pacman/pkg
+    path: "{{ item }}"
     state: directory
     owner: root
     group: root
     mode: "0755"
+  loop:
+    - /var/cache/pacman
+    - /var/cache/pacman/pkg
 
 # Every download that is interrupted (network blip, this permissions bug,
 # an aborted transaction) leaves its "download-<random>" staging directory
 # behind - pacman only cleans these up on a successful download. Left
-# unattended these accumulate without bound. The age filter avoids ever
-# touching a directory that a concurrently running pacman transaction
-# (e.g. a human running pacman -Syu over SSH) might still be writing into.
+# unattended these accumulate without bound.
+#
+# pacman itself serialises all transactions through /var/lib/pacman/db.lck,
+# so that lock's absence is a reliable guarantee no pacman process anywhere
+# is currently writing into any download-* directory (a small -mmin buffer
+# is kept as defence in depth, not as the primary safety check - directory
+# mtime only reflects entries being added/removed, not writes to a file
+# already inside it, so it can't be trusted alone to catch a slow transfer).
+- name: Check whether a pacman transaction is currently in progress
+  ansible.builtin.stat:
+    path: /var/lib/pacman/db.lck
+  register: packages_pacman_lock
+
 - name: Remove stale pacman partial-download directories
   ansible.builtin.command:
     cmd: >-
       find /var/cache/pacman/pkg -maxdepth 1 -type d -name "download-*"
-      -mmin +60 -print -exec rm -rf {} +
+      -mmin +5 -print -exec rm -rf {} +
   register: packages_stale_downloads
+  when: not packages_pacman_lock.stat.exists
   changed_when: packages_stale_downloads.stdout != ""
+  # A directory find already matched can still vanish mid-traversal if a
+  # concurrent process (e.g. pacman itself finishing up and cleaning its
+  # own download dir) removes it first; that's not a real failure, so only
+  # treat this task as failed for errors other than that race.
+  failed_when: >-
+    packages_stale_downloads.rc != 0 and
+    'No such file or directory' not in packages_stale_downloads.stderr
 
 - name: Configure pacman cache server
   ansible.builtin.lineinfile:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Remove stale pacman partial-download directories
   ansible.builtin.command:
     cmd: >-
-      find /var/cache/pacman/pkg -maxdepth 1 -type d -name download-*
+      find /var/cache/pacman/pkg -maxdepth 1 -type d -name "download-*"
       -mmin +60 -print -exec rm -rf {} +
   register: packages_stale_downloads
   changed_when: packages_stale_downloads.stdout != ""

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,4 +1,37 @@
 ---
+# pacman.conf ships "DownloadUser = alpm" by default, so every download
+# (including the Chaotic AUR keyring/mirrorlist pacman -U calls just below)
+# is fetched by the unprivileged "alpm" user sandboxed into a per-download
+# "download-<random>" subdirectory of the cache dir. That sandbox needs
+# execute permission on /var/cache/pacman/pkg itself to open files inside
+# it; if the directory has drifted to something tighter than the package's
+# own shipped mode (root:root 0755, confirmed via the pacman package's
+# mtree metadata), every download fails with "Permission denied" and the
+# whole play aborts here, before any later role ever runs. This must stay
+# the first task in the play (packages is the first role in site.yml) so
+# no download - including the Chaotic AUR ones below - can hit it.
+- name: Ensure pacman package cache directory has correct ownership and mode
+  ansible.builtin.file:
+    path: /var/cache/pacman/pkg
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# Every download that is interrupted (network blip, this permissions bug,
+# an aborted transaction) leaves its "download-<random>" staging directory
+# behind - pacman only cleans these up on a successful download. Left
+# unattended these accumulate without bound. The age filter avoids ever
+# touching a directory that a concurrently running pacman transaction
+# (e.g. a human running pacman -Syu over SSH) might still be writing into.
+- name: Remove stale pacman partial-download directories
+  ansible.builtin.command:
+    cmd: >-
+      find /var/cache/pacman/pkg -maxdepth 1 -type d -name download-*
+      -mmin +60 -print -exec rm -rf {} +
+  register: packages_stale_downloads
+  changed_when: packages_stale_downloads.stdout != ""
+
 - name: Configure pacman cache server
   ansible.builtin.lineinfile:
     path: /etc/pacman.conf

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -49,10 +49,14 @@
   # A directory find already matched can still vanish mid-traversal if a
   # concurrent process (e.g. pacman itself finishing up and cleaning its
   # own download dir) removes it first; that's not a real failure, so only
-  # treat this task as failed for errors other than that race.
+  # treat this task as failed for errors other than that race. Checked
+  # per-line rather than as a substring of the whole stderr blob, so one
+  # benign race on one directory can't mask a genuine error on another.
   failed_when: >-
     packages_stale_downloads.rc != 0 and
-    'No such file or directory' not in packages_stale_downloads.stderr
+    (packages_stale_downloads.stderr_lines
+      | reject('search', 'No such file or directory')
+      | list | length > 0)
 
 - name: Configure pacman cache server
   ansible.builtin.lineinfile:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Every `ansible-pull.service` run has been failing at the very first pacman task
(`packages : Update all packages`), because `/var/cache/pacman/pkg` had drifted
to mode `0750 root:root`. `pacman.conf` ships `DownloadUser = alpm` by default,
which sandboxes every download (including the Chaotic AUR keyring/mirrorlist
`pacman -U` calls) into a per-download `download-<random>` staging directory
under that cache dir, fetched by the unprivileged `alpm` user - who cannot even
traverse into a `0750` directory it doesn't own or belong to the group of.

Since that task has no `ignore_errors`, the whole play was aborting there on
every run, so no role after `packages` (users, docker, ssh, firewall, network,
apparmor, services, ansible_pull, audit, telegraf, reboot) has been applied by
ansible-pull for as long as journal history goes back on the affected host
(checked 14 days; the same failure signature is consistent with it having been
broken since provisioning). The "abnormal pile-up" of stale
`download-*` directories reported was the symptom: pacman only cleans a
download's staging directory up on success, so a failed transaction leaves it
behind, and ~15,773 had accumulated.

Adds two idempotent tasks at the very top of `roles/packages/tasks/main.yml`
(ahead of the Chaotic AUR downloads, which hit the same sandbox):

1. Force `/var/cache/pacman/pkg` back to `owner: root, group: root, mode: "0755"`
   - confirmed via the `pacman` package's own shipped mtree metadata
   (`pacman -Qkk pacman` reports a permissions mismatch against it) that 0755
   is the package's own intended default, not something this hardens away from.
2. Purge stale `download-*` staging directories older than an hour, so the
   pile-up doesn't return. The age filter means a directory a concurrently
   running `pacman -Syu` (e.g. a human over SSH) is still writing into is
   never touched.

Closes #214.

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:

Reproduced the exact reported failure on `arch-vm-test.lan` first:
`chmod 750 /var/cache/pacman/pkg`, then confirmed `sudo -u alpm ls
/var/cache/pacman/pkg` and `pacman -Su` both fail with the identical
`Permission denied` / `could not open file .../*.part` error seen on the
reporting host.

Then ran `ansible-pull` against this branch twice via SSH:
- Run 1: permission task reports `changed`, stale-dir cleanup reports
  `changed`, and the pacman transaction proceeds past the download stage
  entirely (no more `Permission denied`) - it hit an unrelated, transient
  HTTP 500 from the private `pacman.markridgwell.com` cache mirror on one
  package's `.sig` file.
- Run 2 (idempotency check): permission task now reports `ok` (not
  `changed`), confirming it self-heals without churn.
- Final run against `main` on the same VM completed the entire play
  end-to-end: `ok=205 changed=3 failed=0` across all 15 roles - the mirror
  500 was transient.

`ansible-lint` and `yamllint` clean on the changed file and whole repo.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
