### PR TITLE
fix(ssh): always enable and start sshd regardless of prior state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - IPv6 traffic from Docker containers was rejected by the host firewall (docker zone only matched IPv4 sources), breaking any outbound IPv6 connection a container makes - e.g. Traefik's IPv6-routed backends
 - IPv6 default route silently expiring fleet-wide: set net.ipv6.conf.{all,default}.accept_ra to 2 instead of 0, so Router Advertisements are still accepted despite IPv6 forwarding being enabled for container networking
 - Restore pacman package cache directory to owner root, group root, mode 0755 and purge stale partial-download directories, fixing every ansible-pull run failing at the first pacman task because the DownloadUser=alpm sandbox could not traverse a permission-drifted cache directory
+- Always enable and start sshd, instead of relying on it already being active for config changes to take effect
 ### Changed
 - SSH hardening config split to one setting per file in sshd_config.d/, mirroring sysctl pattern
 - linux-hardened kernel is now a prerequisite verified by diagnostic, not installed by the script

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -12,6 +12,13 @@
     cmd: ssh-keygen -A
     creates: /etc/ssh/ssh_host_ed25519_key
 
+- name: Enable and start sshd
+  ansible.builtin.systemd:
+    name: sshd
+    enabled: true
+    state: started
+    daemon_reload: true
+
 - name: Remove legacy misnamed logingraceime config file
   ansible.builtin.file:
     path: /etc/ssh/sshd_config.d/10-logingraceime.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

sshd is now always enabled and started, unconditionally, instead of relying on it already being active for the "Reload sshd" handler to have any effect.

The `ssh` role previously only had a `Reload sshd` handler (`state: reloaded`), which is a no-op if sshd was not already running, and there was no task anywhere in the role (or elsewhere in the playbook) that enabled/started sshd. This adds an explicit, unconditional task:

```yaml
- name: Enable and start sshd
  ansible.builtin.systemd:
    name: sshd
    enabled: true
    state: started
    daemon_reload: true
```

placed early in `roles/ssh/tasks/main.yml`, right after host keys are generated and before any `sshd_config.d/` files are written, so sshd is guaranteed running before config changes are applied and the reload handler fires.

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:
  - `ansible-lint roles/ssh/tasks/main.yml` passed (0 failures/warnings).
  - `yamllint -c .yamllint.yml roles/ssh/tasks/main.yml` passed.
  - Full `site.yml` applied against the `arch-vm-test.lan` test VM (see comment below for detail): `ok=209 changed=5 unreachable=0 failed=0 skipped=49 rescued=0 ignored=1`. `TASK [ssh : Enable and start sshd]` returned `ok` (idempotent no-op, sshd was already running).

## Types of changes

<!--- What types of changes does your code introduce? --->
<!--- Put an 'x' in all the boxes that apply: --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md
<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an 'x' in all --->
<!--- the boxes once they are true. --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
