### PR TITLE
feat(pacman): enable ILoveCandy, CheckSpace and VerbosePkgLists options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Install and configure Telegraf to report host and container metrics to https://metrics.markridgwell.com
 - Enable and start serial-getty@ttyS0.service via the services role, giving VMs a browser-copy/paste-capable serial console that keeps working when guest networking is down
 - Configure a system-wide coloured Starship prompt for all users
+- Enable ILoveCandy, CheckSpace and VerbosePkgLists options in pacman.conf
 ### Fixed
 - Add --needed flag to chaotic-aur package installs to skip reinstalling already-up-to-date packages
 - Add --needed to pacman -U for Chaotic AUR keyring and mirrorlist installs to avoid re-installing on every script run

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -67,6 +67,24 @@
     insertafter: "^Include = /etc/pacman.d/mirrorlist$"
     state: present
 
+# ILoveCandy, CheckSpace and VerbosePkgLists are plain flag directives (no
+# "= value") under [options]. Each may already be present (commented or
+# not, per the shipped pacman.conf template) or entirely absent (ILoveCandy
+# isn't in the template at all), so match on an optional leading "#" and
+# fall back to inserting a fresh line straight after the [options] header
+# when there's nothing to match.
+- name: Enable pacman [options] flags
+  ansible.builtin.lineinfile:
+    path: /etc/pacman.conf
+    regexp: "^#?{{ item }}$"
+    line: "{{ item }}"
+    insertafter: "^\\[options\\]$"
+    state: present
+  loop:
+    - ILoveCandy
+    - CheckSpace
+    - VerbosePkgLists
+
 - name: Check if Chaotic AUR signing key is already trusted
   ansible.builtin.command:
     cmd: pacman-key --list-keys 3056513887B78AEB


### PR DESCRIPTION
# Description

Enables three pacman `[options]` flag directives on the target host's
`/etc/pacman.conf`:

- `ILoveCandy` - colourised progress bar (not present in the default
  template at all, so it needs inserting rather than uncommenting)
- `CheckSpace` - checks free disk space before a transaction
- `VerbosePkgLists` - shows name/version/size in transaction summaries

Added via a new `lineinfile`-based task in `roles/packages/tasks/main.yml`,
matching the style of the existing `Configure pacman cache server` task.
Each option is matched with an optional leading `#` and reinserted
uncommented directly after `[options]`, so it works whether the line is
already present (commented or not) or entirely absent.

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [x] Manual Testing:
  - `ansible-lint roles/packages/tasks/main.yml` passed (0 failures/warnings).
  - Full `site.yml` applied twice against `arch-vm-test.lan`: first run
    `failed=0 unreachable=0`, confirmed `ILoveCandy`, `CheckSpace` and
    `VerbosePkgLists` all present and uncommented in `/etc/pacman.conf`;
    second run reported `ok` (no `changed`) for all three items, confirming
    idempotency.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

## Checklist

- [ ] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
- [x] No user-controlled or step-output value is string-interpolated directly into a `run:`/`script:` body (workflow or composite action); pass it via step-level `env:` and reference `$VAR` (bash) or `process.env.VAR` (github-script) instead.